### PR TITLE
Self host canvaskit

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -50,7 +50,7 @@ WORKDIR /usr/local/src/app
 RUN flutter packages get
 
 # Build the app for the web
-RUN flutter build web
+RUN flutter build web --release --dart-define=FLUTTER_WEB_CANVASKIT_URL=/canvaskit/
 
 # ------------
 # RUNNER


### PR DESCRIPTION
I noticed that both google fonts as well as canvaskit are not "self-hosted" but fetched from CDNs.

Flutter does not yet provide options to completely self host fonts but has a solution for canvaskit (https://github.com/flutter/flutter/issues/60069#issuecomment-1152340236). As such I propose this change to make use of this functionality.

I hope this is in the spirit of the project as it will increase the "self-hosting" aspect.

Maybe in the future even google fonts can be self hosted, allowing the project to be deployed completely offline.