### PR TITLE
feat: use chrome custom tabs for links

### DIFF
--- a/lib/cubits/auth_cubit.dart
+++ b/lib/cubits/auth_cubit.dart
@@ -29,7 +29,7 @@ class AuthCubit extends Cubit<AuthState> {
     String? url;
     url = kIsWeb
         ? kDebugMode
-            ? "http://localhost:8010/proxy"
+            ? "http://localhost:5000"
             : Uri.base.origin
         : await PreferenceStorage.getInstance().read(key: 'URL');
     if (url != null && url.isNotEmpty) {

--- a/lib/cubits/auth_cubit.dart
+++ b/lib/cubits/auth_cubit.dart
@@ -29,7 +29,7 @@ class AuthCubit extends Cubit<AuthState> {
     String? url;
     url = kIsWeb
         ? kDebugMode
-            ? "http://localhost:5000"
+            ? "http://localhost:8010/proxy"
             : Uri.base.origin
         : await PreferenceStorage.getInstance().read(key: 'URL');
     if (url != null && url.isNotEmpty) {

--- a/lib/helpers/url_launcher.dart
+++ b/lib/helpers/url_launcher.dart
@@ -1,16 +1,28 @@
 import 'dart:io';
 
+import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 import 'package:url_launcher/url_launcher.dart' as ul;
 import 'package:flutter_custom_tabs/flutter_custom_tabs.dart';
 
 Future<void> openUrl(BuildContext context, String url) async {
-  return (Platform.isAndroid || Platform.isIOS)
+  return (!kIsWeb && (Platform.isAndroid || Platform.isIOS))
       ? await launch(
           url,
           customTabsOption: CustomTabsOption(
-            toolbarColor: Theme.of(context).primaryColor,
+            toolbarColor: Theme.of(context).colorScheme.primary,
             enableDefaultShare: true,
+            extraCustomTabs: const [
+              'org.mozilla.firefox',
+              'com.microsoft.emmx',
+            ],
+          ),
+          safariVCOption: SafariViewControllerOption(
+            preferredBarTintColor: Theme.of(context).colorScheme.primary,
+            preferredControlTintColor: Theme.of(context).colorScheme.onPrimary,
+            barCollapsingEnabled: true,
+            entersReaderIfAvailable: false,
+            dismissButtonStyle: SafariViewControllerDismissButtonStyle.close,
           ),
         )
       : await ul.launchUrl(Uri.parse(url));

--- a/lib/helpers/url_launcher.dart
+++ b/lib/helpers/url_launcher.dart
@@ -1,0 +1,22 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_custom_tabs/flutter_custom_tabs.dart';
+
+Future<void> openUrl(BuildContext context, String url) async {
+  await launch(
+    url,
+    customTabsOption: CustomTabsOption(
+      toolbarColor: Theme.of(context).primaryColor,
+      enableDefaultShare: true,
+    ),
+  );
+}
+
+Future<bool> isValidUrl(String url) async {
+  try {
+    var uri = Uri.parse(url);
+
+    return uri.scheme == "http" || uri.scheme == "https";
+  } catch (e) {
+    return false;
+  }
+}

--- a/lib/helpers/url_launcher.dart
+++ b/lib/helpers/url_launcher.dart
@@ -1,14 +1,19 @@
+import 'dart:io';
+
 import 'package:flutter/material.dart';
+import 'package:url_launcher/url_launcher.dart' as ul;
 import 'package:flutter_custom_tabs/flutter_custom_tabs.dart';
 
 Future<void> openUrl(BuildContext context, String url) async {
-  await launch(
-    url,
-    customTabsOption: CustomTabsOption(
-      toolbarColor: Theme.of(context).primaryColor,
-      enableDefaultShare: true,
-    ),
-  );
+  return (Platform.isAndroid || Platform.isIOS)
+      ? await launch(
+          url,
+          customTabsOption: CustomTabsOption(
+            toolbarColor: Theme.of(context).primaryColor,
+            enableDefaultShare: true,
+          ),
+        )
+      : await ul.launchUrl(Uri.parse(url));
 }
 
 Future<bool> isValidUrl(String url) async {

--- a/lib/helpers/url_launcher.dart
+++ b/lib/helpers/url_launcher.dart
@@ -6,6 +6,8 @@ import 'package:url_launcher/url_launcher.dart' as ul;
 import 'package:flutter_custom_tabs/flutter_custom_tabs.dart';
 
 Future<void> openUrl(BuildContext context, String url) async {
+  if (!isValidUrl(url)) return;
+
   return (!kIsWeb && (Platform.isAndroid || Platform.isIOS))
       ? await launch(
           url,
@@ -28,7 +30,7 @@ Future<void> openUrl(BuildContext context, String url) async {
       : await ul.launchUrl(Uri.parse(url));
 }
 
-Future<bool> isValidUrl(String url) async {
+bool isValidUrl(String url) {
   try {
     var uri = Uri.parse(url);
 

--- a/lib/pages/recipe_page.dart
+++ b/lib/pages/recipe_page.dart
@@ -6,13 +6,13 @@ import 'package:kitchenowl/app.dart';
 import 'package:kitchenowl/cubits/recipe_cubit.dart';
 import 'package:kitchenowl/cubits/settings_cubit.dart';
 import 'package:kitchenowl/enums/update_enum.dart';
+import 'package:kitchenowl/helpers/url_launcher.dart';
 import 'package:kitchenowl/models/item.dart';
 import 'package:kitchenowl/models/recipe.dart';
 import 'package:kitchenowl/pages/recipe_add_update_page.dart';
 import 'package:kitchenowl/kitchenowl.dart';
 import 'package:kitchenowl/widgets/recipe_source_chip.dart';
 import 'package:cached_network_image/cached_network_image.dart';
-import 'package:url_launcher/url_launcher_string.dart';
 
 class RecipePage extends StatefulWidget {
   final Recipe recipe;
@@ -170,9 +170,8 @@ class _RecipePageState extends State<RecipePage> {
                                   const Icon(Icons.error),
                             ),
                             onTapLink: (text, href, title) async {
-                              if (href != null &&
-                                  await canLaunchUrlString(href)) {
-                                await launchUrlString(href);
+                              if (href != null && await isValidUrl(href)) {
+                                await openUrl(context, href);
                               }
                             },
                           ),

--- a/lib/pages/recipe_page.dart
+++ b/lib/pages/recipe_page.dart
@@ -169,9 +169,9 @@ class _RecipePageState extends State<RecipePage> {
                               errorWidget: (context, url, error) =>
                                   const Icon(Icons.error),
                             ),
-                            onTapLink: (text, href, title) async {
-                              if (href != null && await isValidUrl(href)) {
-                                await openUrl(context, href);
+                            onTapLink: (text, href, title) {
+                              if (href != null && isValidUrl(href)) {
+                                openUrl(context, href);
                               }
                             },
                           ),

--- a/lib/widgets/recipe_source_chip.dart
+++ b/lib/widgets/recipe_source_chip.dart
@@ -1,67 +1,44 @@
 import 'package:flutter/material.dart';
 import 'package:kitchenowl/helpers/url_launcher.dart';
 
-class RecipeSourceChip extends StatefulWidget {
+class RecipeSourceChip extends StatelessWidget {
   final String source;
 
-  const RecipeSourceChip({Key? key, required this.source}) : super(key: key);
-
-  @override
-  State<RecipeSourceChip> createState() => _RecipeSourceChipState();
-}
-
-class _RecipeSourceChipState extends State<RecipeSourceChip> {
-  Future<bool> canLaunchUrl = Future.value(true);
-
-  @override
-  void initState() {
-    super.initState();
-    canLaunchUrl = isValidUrl(widget.source);
-  }
+  const RecipeSourceChip({super.key, required this.source});
 
   @override
   Widget build(BuildContext context) {
-    return FutureBuilder(
-      future: canLaunchUrl,
-      initialData: false,
-      builder: (
-        context,
-        AsyncSnapshot<bool> snapshot,
-      ) =>
-          snapshot.data!
-              ? ActionChip(
-                  avatar: Icon(
-                    Icons.link,
-                    color: Theme.of(context).colorScheme.onPrimary,
-                  ),
-                  label: Text(
-                    snapshot.data!
-                        ? Uri.tryParse(widget.source)?.host ?? widget.source
-                        : widget.source,
-                    style: TextStyle(
-                      color: Theme.of(context).colorScheme.onPrimary,
-                    ),
-                  ),
-                  backgroundColor: Theme.of(context).colorScheme.primary,
-                  elevation: 3,
-                  onPressed: () async {
-                    await openUrl(context, widget.source);
-                  },
-                )
-              : Chip(
-                  avatar: Icon(
-                    Icons.book_rounded,
-                    color: Theme.of(context).colorScheme.onPrimary,
-                  ),
-                  label: Text(
-                    widget.source,
-                    style: TextStyle(
-                      color: Theme.of(context).colorScheme.onPrimary,
-                    ),
-                  ),
-                  backgroundColor: Theme.of(context).colorScheme.primary,
-                  elevation: 3,
-                ),
+    if (isValidUrl(source)) {
+      return ActionChip(
+        avatar: Icon(
+          Icons.link,
+          color: Theme.of(context).colorScheme.onPrimary,
+        ),
+        label: Text(
+          Uri.tryParse(source)?.host ?? source,
+          style: TextStyle(
+            color: Theme.of(context).colorScheme.onPrimary,
+          ),
+        ),
+        backgroundColor: Theme.of(context).colorScheme.primary,
+        elevation: 3,
+        onPressed: () => openUrl(context, source),
+      );
+    }
+
+    return Chip(
+      avatar: Icon(
+        Icons.book_rounded,
+        color: Theme.of(context).colorScheme.onPrimary,
+      ),
+      label: Text(
+        source,
+        style: TextStyle(
+          color: Theme.of(context).colorScheme.onPrimary,
+        ),
+      ),
+      backgroundColor: Theme.of(context).colorScheme.primary,
+      elevation: 3,
     );
   }
 }

--- a/lib/widgets/recipe_source_chip.dart
+++ b/lib/widgets/recipe_source_chip.dart
@@ -1,8 +1,9 @@
 import 'package:flutter/material.dart';
-import 'package:url_launcher/url_launcher_string.dart';
+import 'package:kitchenowl/helpers/url_launcher.dart';
 
 class RecipeSourceChip extends StatefulWidget {
   final String source;
+
   const RecipeSourceChip({Key? key, required this.source}) : super(key: key);
 
   @override
@@ -10,12 +11,12 @@ class RecipeSourceChip extends StatefulWidget {
 }
 
 class _RecipeSourceChipState extends State<RecipeSourceChip> {
-  late Future<bool> canLaunchUrl;
+  Future<bool> canLaunchUrl = Future.value(true);
 
   @override
   void initState() {
     super.initState();
-    canLaunchUrl = canLaunchUrlString(widget.source);
+    canLaunchUrl = isValidUrl(widget.source);
   }
 
   @override
@@ -44,13 +45,7 @@ class _RecipeSourceChipState extends State<RecipeSourceChip> {
                   backgroundColor: Theme.of(context).colorScheme.primary,
                   elevation: 3,
                   onPressed: () async {
-                    if (await canLaunchUrlString(
-                      widget.source,
-                    )) {
-                      await launchUrlString(
-                        widget.source,
-                      );
-                    }
+                    await openUrl(context, widget.source);
                   },
                 )
               : Chip(

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -39,7 +39,6 @@ dependencies:
   shimmer: ^2.0.0
   equatable: ^2.0.5
   flutter_custom_tabs: ^1.0.4
-  url_launcher: ^6.1.6
   package_info_plus: ^3.0.1
   device_info_plus: ^8.0.0
   http: ^0.13.5

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -38,6 +38,7 @@ dependencies:
   animations: ^2.0.7
   shimmer: ^2.0.0
   equatable: ^2.0.5
+  url_launcher: ^6.1.6
   flutter_custom_tabs: ^1.0.4
   package_info_plus: ^3.0.1
   device_info_plus: ^8.0.0

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -38,6 +38,7 @@ dependencies:
   animations: ^2.0.7
   shimmer: ^2.0.0
   equatable: ^2.0.5
+  flutter_custom_tabs: ^1.0.4
   url_launcher: ^6.1.6
   package_info_plus: ^3.0.1
   device_info_plus: ^8.0.0


### PR DESCRIPTION
Use chrome custom tabs on Android for links.

This allows users to share the link of a recipe and also arguably gives a better browser experience on Android.
