### PR TITLE
fix not working with ipv6 disabled in issue #105

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -59,6 +59,7 @@ FROM nginx:stable-alpine
 
 RUN mkdir -p /var/www/web/kitchenowl
 COPY --from=builder /usr/local/src/app/build/web /var/www/web/kitchenowl
+COPY docker-entrypoint-custom.sh /docker-entrypoint.d/01-kitchenowl-customization.sh
 COPY default.conf.template /etc/nginx/templates/
 
 HEALTHCHECK --interval=5m --timeout=3s \

--- a/docker-entrypoint-custom.sh
+++ b/docker-entrypoint-custom.sh
@@ -2,6 +2,7 @@
 
 set -e
 
+ME=$(basename $0)
 entrypoint_log() {
     if [ -z "${NGINX_ENTRYPOINT_QUIET_LOGS:-}" ]; then
         echo "$@"

--- a/docker-entrypoint-custom.sh
+++ b/docker-entrypoint-custom.sh
@@ -1,0 +1,15 @@
+#!/bin/sh
+
+set -e
+
+entrypoint_log() {
+    if [ -z "${NGINX_ENTRYPOINT_QUIET_LOGS:-}" ]; then
+        echo "$@"
+    fi
+}
+
+# if ipv6 is unavailable, remove it from the nginx template
+if [ ! -f "/proc/net/if_inet6" ]; then
+    entrypoint_log "$ME: info: ipv6 not available"
+    sed -i '/::/d' /etc/nginx/templates/default.conf.template
+fi


### PR DESCRIPTION
- check if IPv6 is available in the container
- if not, disable IPv6 in kitchenowl's NGINX config
- provide a custom docker-entrypoint script for future adjustments to use