### PR TITLE
fix: remove reorder hint from shopping list settings

### DIFF
--- a/lib/widgets/settings_household/sliver_household_shoppinglist_settings.dart
+++ b/lib/widgets/settings_household/sliver_household_shoppinglist_settings.dart
@@ -121,7 +121,7 @@ class SliverHouseholdShoppinglistSettings extends StatelessWidget {
       ),
       SliverToBoxAdapter(
         child: Text(
-          AppLocalizations.of(context)!.swipeToDeleteAndLongPressToReorder,
+          AppLocalizations.of(context)!.swipeToDelete,
           textAlign: TextAlign.center,
           style: Theme.of(context).textTheme.bodySmall,
         ),


### PR DESCRIPTION
As mentioned in #159 