### PR TITLE
Add Traefik and Authelia config examples to KitchenOwl docs

### DIFF
--- a/docs/self-hosting/index.md
+++ b/docs/self-hosting/index.md
@@ -34,7 +34,7 @@ volumes:
 
 
 !!! danger "Important"
-    We recommend running KitchenOwl behind a reverse proxy with HTTPS (e.g. [nginx](https://nginx.org/en/docs/http/configuring_https_servers.html))
+    We recommend running KitchenOwl behind a reverse proxy with HTTPS (e.g. [nginx](https://nginx.org/en/docs/http/configuring_https_servers.html) or [Traefik](https://doc.traefik.io/traefik/)). Some [example configurations have been contributed](reverse-proxy.md).
 
     It is also important that you have HTTP Strict Transport Security enabled and the proper headers applied to your responses or you could be subject to a javascript hijack.
 

--- a/docs/self-hosting/oidc.md
+++ b/docs/self-hosting/oidc.md
@@ -60,4 +60,30 @@ back:
         - APPLE_CLIENT_SECRET=<SECRET>
         - GOOGLE_CLIENT_ID=<ID>
         - GOOGLE_CLIENT_SECRET=<SECRET>
+
+```
+
+### Authelia
+
+[Authelia](https://www.authelia.com/) is an open-source authentication and authorization server and portal fulfilling the identity and access management (IAM) role of information security in providing multi-factor authentication and single sign-on (SSO) for your applications via a web portal. It acts as a companion for common reverse proxies.
+
+Place this in your Authelia [configuration.yaml](https://www.authelia.com/configuration/prologue/introduction/) to allow KitchenOwl to use Authelia as an OIDC provider.
+
+```yml
+- id: kitchenowl
+    description: KitchenOwl
+    secret: # Same as OIDC_CLIENT_SECRET
+    public: false
+    authorization_policy: two_factor # Can also be one_factor if you need less security
+    pre_configured_consent_duration: 1M # One month - change this to something you desire
+    audience: []
+    scopes:
+        - openid
+        - email
+        - profile
+    redirect_uris:
+        - https://your.domain.here/signin/redirect # Put the same value as FRONT_URL, appended with /signin/redirect
+        - kitchenowl:///signin/redirect
+    response_modes:
+    userinfo_signing_algorithm: none
 ```

--- a/docs/self-hosting/reverse-proxy.md
+++ b/docs/self-hosting/reverse-proxy.md
@@ -1,0 +1,64 @@
+# Reverse proxy configurations
+
+### Traefik v2
+
+This example configuration assumes that you are:
+
+* Running Traefik on the `web` docker network
+* Use the entrypoint `websecure` for HTTPS and have configured it for a wildcard SSL certificate
+* Have a security@docker middleware (see below)
+
+
+```yml
+version: "3"
+
+services:
+  front:
+    image: tombursch/kitchenowl-web:latest
+    networks:
+      - default
+      - web
+    restart: unless-stopped
+    depends_on:
+      - back
+    labels:
+      - "traefik.enable=true"
+      - "traefik.docker.network=web"
+      - "traefik.http.routers.kitchenowl.rule=Host(`your.domain.here`)"
+      - "traefik.http.routers.kitchenowl.entrypoints=websecure"
+      - 'traefik.http.routers.kitchenowl.middlewares=security@docker' # Use to apply security middlewares
+
+  back:
+    image: tombursch/kitchenowl:latest
+    networks:
+      - default
+    restart: unless-stopped
+    environment:
+      - FRONT_URL=https://your.domain.here
+      - JWT_SECRET_KEY=PLEASE_CHANGE_ME
+    volumes:
+      - kitchenowl_data:/data
+
+networks:
+  web:
+    external: true
+
+volumes:
+  kitchenowl_data:
+```
+
+Traefik can add extra security headers to add a level of protection to your KitchenOwl instance. You can specify a middleware in your Traefik docker-compose.yml using labels.
+
+```yml
+  labels:
+    - 'traefik.http.middlewares.security.headers.addvaryheader=true'
+    - 'traefik.http.middlewares.security.headers.sslredirect=true'
+    - 'traefik.http.middlewares.security.headers.browserxssfilter=true'
+    - 'traefik.http.middlewares.security.headers.contenttypenosniff=true'
+    - 'traefik.http.middlewares.security.headers.forcestsheader=true'
+    - 'traefik.http.middlewares.security.headers.stsincludesubdomains=true'
+    - 'traefik.http.middlewares.security.headers.stspreload=true'
+    - 'traefik.http.middlewares.security.headers.stsseconds=63072000'
+    - 'traefik.http.middlewares.security.headers.customframeoptionsvalue=SAMEORIGIN'
+    - 'traefik.http.middlewares.security.headers.referrerpolicy=same-origin'
+```


### PR DESCRIPTION
These are the configurations I successfully use for Traefik reverse proxy and Authelia OIDC.