### PR TITLE
Feat: add EXPOSE directive to Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -107,3 +107,5 @@ RUN chmod u+x ./entrypoint.sh
 
 CMD ["--ini", "wsgi.ini:web", "--gevent", "200"]
 ENTRYPOINT ["./entrypoint.sh"]
+
+EXPOSE 8080


### PR DESCRIPTION
Noticed that out of the box, the all-in-one image doesn't currently EXPOSE a port, so Traefik and friends won't auto-discover it.

Hope this isn't somehow intentional :D