### PR TITLE
Add media-types to Docker container build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -78,7 +78,7 @@ FROM python:3.12-slim as runner
 
 RUN apt-get update \
     && apt-get install --yes --no-install-recommends \
-        libxml2 libpcre3 curl \
+        libxml2 libpcre3 curl media-types \
     && rm -rf /var/lib/apt/lists/*
 
 # Use virtual enviroment

--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -25,7 +25,7 @@ FROM python:3.12-slim as runner
 
 RUN apt-get update \
     && apt-get install --yes --no-install-recommends \
-        libxml2 libpcre3 curl \
+        libxml2 libpcre3 curl media-types \
     && rm -rf /var/lib/apt/lists/*
 
 # Use virtual enviroment


### PR DESCRIPTION
Fixes #477 by adding the media-types package to the Docker container build.