### PR TITLE
Fix Self-Hosted docs url

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@
 <h4 align="center">
   <a href="https://kitchenowl.org">Website</a> |
   <a href="https://docs.kitchenowl.org">Docs</a> |
-  <a href="https://docs.kitchenowl.org/self-hosting/">Self-Hosting</a> |
+  <a href="https://docs.kitchenowl.org/latest/self-hosting/">Self-Hosting</a> |
   <a href="https://matrix.to/#/#kitchenowl:matrix.org">Matrix</a>
 </h4>
 
@@ -82,7 +82,7 @@ Get it in your favorite store or find the current release for your operating sys
 
 ## 🚀 Get started
 
-Please take a look at the [get started guide](https://docs.kitchenowl.org/self-hosting/).
+Please take a look at the [get started guide](https://docs.kitchenowl.org/latest/self-hosting/).
 
 ## 🙌 Contributing
 


### PR DESCRIPTION
Fixes Self-Hosted links url wich are not working on the current README.

Great project!
Regards