### PR TITLE
Adds dependency to gevent-socket

### DIFF
--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -49,6 +49,7 @@ frozenlist==1.5.0
 fsspec==2024.10.0
 future==1.0.0
 gevent==24.11.1
+gevent-websocket==0.10.1
 greenlet==3.1.1
 h11==0.14.0
 html5lib==1.1


### PR DESCRIPTION
When running without this requirement I received the following warning:

```
2024-12-12 12:49:48,689] WARNING in __init__: WebSocket transport not available. Install gevent-websocket for improved performance.
```