### PR TITLE
Feat: Real-time sync shopping lists addition/removal

### DIFF
--- a/kitchenowl/lib/cubits/household_add_update/household_update_cubit.dart
+++ b/kitchenowl/lib/cubits/household_add_update/household_update_cubit.dart
@@ -28,6 +28,16 @@ class HouseholdUpdateCubit
     ApiService.getInstance()
         .getSupportedLanguages()
         .then((value) => emit(state.copyWith(supportedLanguages: value)));
+    ApiService.getInstance().onShoppinglistAdd(onShoppinglistAdd);
+    ApiService.getInstance().onShoppinglistDelete(onShoppinglistDelete);
+  }
+
+  void onShoppinglistAdd(dynamic data) {
+    refresh();
+  }
+  
+  void onShoppinglistDelete(dynamic data) {
+    refresh();
   }
 
   Future<void> refresh() async {

--- a/kitchenowl/lib/services/api/shoppinglist.dart
+++ b/kitchenowl/lib/services/api/shoppinglist.dart
@@ -138,6 +138,22 @@ extension ShoppinglistApi on ApiService {
     return res.statusCode == 200;
   }
 
+  void onShoppinglistAdd(dynamic Function(dynamic) handler){
+    socket.on("shoppinglist:add", handler);
+  }
+
+  void offShoppinglistAdd(dynamic Function(dynamic) handler){
+    socket.off("shoppinglist:add", handler);
+  }
+
+  void onShoppinglistDelete(dynamic Function(dynamic) handler){
+    socket.on("shoppinglist:delete", handler);
+  }
+
+  void offShoppinglistDelete(dynamic Function(dynamic) handler){
+    socket.off("shoppinglist:delete", handler);
+  }
+
   void onShoppinglistItemAdd(dynamic Function(dynamic) handler) {
     socket.on("shoppinglist_item:add", handler);
   }


### PR DESCRIPTION
Add real-time synchronization to shopping lists
    
 Adding or removing shopping lists now immediately
 updates them in the available shopping list selector
 in the "add items" overview.

I'm not entirely sure if calling `refresh()` is enough. At least in my tests it was but I'm not sure if there are side-effects missing that I don't know about.

When you use the Linux or Android App and have Chrome open at the same time the update in Chrome happens once the window has focus. Not sure what that is about.

**Again this PR is only a draft** as it depends on other PRs. I'll rebase onto main once those are complete.
