### PR TITLE
chore: Add flutter version constraint to pubspec

### DIFF
--- a/kitchenowl/pubspec.yaml
+++ b/kitchenowl/pubspec.yaml
@@ -19,6 +19,7 @@ version: 0.6.4+102
 
 environment:
   sdk: ">=3.0.0 <4.0.0"
+  flutter: ">=3.27.0"
 
 dependencies:
   flutter:


### PR DESCRIPTION
I had version 3.24.5 installed and after updating to the latest head I started getting problems on build.

One of them was:

![image](https://github.com/user-attachments/assets/c05a70ea-63c7-4b29-9ff3-15e868376423)

Which is odd because before updating it just worked.

After some time I noticed that the futter submodule had been updated to version 3.27.

After installing version 3.27.x of the flutter SDK everything started building again.

To not have this happen in the future it's best if we keep the necessary flutter version in the pubspec to get a better error in the future.

The only chore now is that when updating the flutter submodule the pubspec must also be updated.