### PR TITLE
feat: Allow adding and removing shopping lists more easily

### DIFF
--- a/backend/app/controller/shoppinglist/shoppinglist_controller.py
+++ b/backend/app/controller/shoppinglist/shoppinglist_controller.py
@@ -103,7 +103,16 @@ def updateShoppinglist(args, id):
         shoppinglist.name = args["name"]
 
     shoppinglist.save()
-    return jsonify(shoppinglist.obj_to_dict())
+    shoppinglist_dict = shoppinglist.obj_to_dict();
+    socketio.emit(
+        "shoppinglist:update",
+        {
+            "shoppinglist": shoppinglist_dict
+        },
+        to=shoppinglist.household_id
+    )
+
+    return jsonify(shoppinglist_dict)
 
 
 @shoppinglist.route("/<int:id>", methods=["DELETE"])

--- a/kitchenowl/lib/l10n/app_en.arb
+++ b/kitchenowl/lib/l10n/app_en.arb
@@ -299,6 +299,7 @@
   "@setupTitle": {},
   "@share": {},
   "@shoppingList": {},
+  "@shoppingListAddTooltip": {},
   "@shoppingListContainsEntries": {
     "placeholders": {
       "entriesCount": {
@@ -600,6 +601,7 @@
   "setupTitle": "Hey there! Ready to shop?",
   "share": "Share",
   "shoppingList": "Shopping list",
+  "shoppingListAddTooltip": "Add a shopping list",
   "shoppingListContainsEntries": "{entriesCount, plural, =0{The shopping list contains no items.} =1{The shopping list contains 1 item.} other{The shopping list contains {entriesCount} items.}}",
   "shoppingListDelete": "Delete shopping list",
   "shoppingListDeleteConfirmation": "Are you sure you want to delete {shoppingList}?",

--- a/kitchenowl/lib/models/household.dart
+++ b/kitchenowl/lib/models/household.dart
@@ -43,7 +43,7 @@ class Household extends Model {
       member = List.from(map['member'].map((e) => Member.fromJson(e)));
     }
 
-    return Household(
+    final household = Household(
       id: map['id'],
       name: map['name'],
       image: map['photo'],
@@ -57,6 +57,8 @@ class Household extends Model {
           ? ShoppingList.fromJson(map['default_shopping_list'])
           : null,
     );
+
+    return household;
   }
 
   Household copyWith({
@@ -66,6 +68,7 @@ class Household extends Model {
     bool? featurePlanner,
     bool? featureExpenses,
     List<ViewsEnum>? viewOrdering,
+    ShoppingList? defaultShoppingList
   }) =>
       Household(
         id: id,
@@ -76,6 +79,7 @@ class Household extends Model {
         featurePlanner: featurePlanner ?? this.featurePlanner,
         featureExpenses: featureExpenses ?? this.featureExpenses,
         viewOrdering: viewOrdering ?? this.viewOrdering,
+        defaultShoppingList: defaultShoppingList ?? this.defaultShoppingList
       );
 
   @override

--- a/kitchenowl/lib/pages/household_page/shoppinglist.dart
+++ b/kitchenowl/lib/pages/household_page/shoppinglist.dart
@@ -7,6 +7,7 @@ import 'package:kitchenowl/cubits/shoppinglist_cubit.dart';
 import 'package:kitchenowl/enums/shoppinglist_sorting.dart';
 import 'package:kitchenowl/models/item.dart';
 import 'package:kitchenowl/kitchenowl.dart';
+import 'package:kitchenowl/pages/settings_household/household_settings_shoppinglist_page.dart';
 import 'package:kitchenowl/widgets/choice_scroll.dart';
 import 'package:kitchenowl/widgets/shopping_list/shopping_list_choice_chip.dart';
 import 'package:kitchenowl/widgets/shopping_list/sliver_shopinglist_item_view.dart';
@@ -120,29 +121,70 @@ class _ShoppinglistPageState extends State<ShoppinglistPage> {
                         headerSliverBuilder: (context, innerBoxIsScrolled) => [
                           SliverToBoxAdapter(
                             child: LeftRightWrap(
-                              left: (state.shoppinglists.length < 2)
-                                  ? const SizedBox()
-                                  : ChoiceScroll(
-                                      children: state.shoppinglists.values
-                                          .sorted((a, b) => b.items.length
-                                              .compareTo(a.items.length))
-                                          .map(
-                                            (shoppinglist) =>
-                                                ShoppingListChoiceChip(
-                                              shoppingList: shoppinglist,
-                                              selected: shoppinglist.id ==
-                                                  state.selectedShoppinglistId,
-                                              onSelected: (bool selected) {
-                                                if (selected) {
-                                                  cubit.setShoppingList(
-                                                    shoppinglist,
-                                                  );
-                                                }
-                                              },
-                                            ),
-                                          )
-                                          .toList(),
-                                    ),
+                              left: Row(
+                                children: [
+                                  IconButton(
+                                      tooltip: AppLocalizations.of(context)!
+                                          .shoppingListAddTooltip,
+                                      onPressed: () async {
+                                        final res =
+                                            await HouseholdSettingsShoppinglistPage
+                                                .getShoppingListName(context,
+                                                    state.shoppinglists.values);
+                                        if (res != null) {
+                                          BlocProvider.of<ShoppinglistCubit>(
+                                                  context)
+                                              .addShoppingList(res);
+                                        }
+                                      },
+                                      icon: Icon(Icons.add,
+                                          color: Theme.of(context)
+                                              .colorScheme
+                                              .primary)),
+                                  (state.shoppinglists.length < 2)
+                                      ? const SizedBox()
+                                      : ChoiceScroll(
+                                          paddingLeft: 0,
+                                          children: state.shoppinglists.values
+                                              .sorted((a, b) =>
+                                                  a.name.compareTo(b.name))
+                                              .map(
+                                                (shoppinglist) =>
+                                                    ShoppingListChoiceChip(
+                                                        canDelete: state
+                                                                .defaultShoppingList !=
+                                                            shoppinglist,
+                                                        shoppingList:
+                                                            shoppinglist,
+                                                        selected: shoppinglist
+                                                                .id ==
+                                                            state
+                                                                .selectedShoppinglistId,
+                                                        onSelected:
+                                                            (bool selected) {
+                                                          if (selected) {
+                                                            cubit
+                                                                .setShoppingList(
+                                                              shoppinglist,
+                                                            );
+                                                          }
+                                                        },
+                                                        onDeleted: () async {
+                                                          final doIt =
+                                                              await HouseholdSettingsShoppinglistPage
+                                                                  .confirmDeleteShoppingList(
+                                                                      context,
+                                                                      shoppinglist);
+                                                          if (doIt) {
+                                                            cubit.deleteShoppingList(
+                                                                shoppinglist);
+                                                          }
+                                                        }),
+                                              )
+                                              .toList(),
+                                        ),
+                                ],
+                              ),
                               right: Padding(
                                 padding:
                                     const EdgeInsets.only(right: 16, bottom: 6),

--- a/kitchenowl/lib/pages/settings_household/household_settings_shoppinglist_page.dart
+++ b/kitchenowl/lib/pages/settings_household/household_settings_shoppinglist_page.dart
@@ -38,37 +38,45 @@ class HouseholdSettingsShoppinglistPage extends StatelessWidget {
         ));
   }
 
+  static Future<String?> getShoppingListName(
+      BuildContext context, Iterable<ShoppingList> shoppingLists) async {
+    return await showDialog<String>(
+      context: context,
+      builder: (BuildContext context) {
+        return TextDialog(
+          title: AppLocalizations.of(context)!.addShoppingList,
+          doneText: AppLocalizations.of(context)!.add,
+          hintText: AppLocalizations.of(context)!.name,
+          isInputValid: (s) =>
+              s.isNotEmpty &&
+              !shoppingLists.any((shoppingList) => shoppingList.name == s),
+        );
+      },
+    );
+  }
+
   @override
   Widget build(BuildContext context) {
     return Scaffold(
       body: CustomScrollView(
         slivers: [
           SliverAppBar(
-            title: Text(AppLocalizations.of(context)!.shoppingLists),
-            actions: [
-              IconButton(
-                icon: const Icon(Icons.add),
-                tooltip: AppLocalizations.of(context)!.addShoppingList,
-                onPressed: () async {
-                  final res = await showDialog<String>(
-                    context: context,
-                    builder: (BuildContext context) {
-                      return TextDialog(
-                        title: AppLocalizations.of(context)!.addShoppingList,
-                        doneText: AppLocalizations.of(context)!.add,
-                        hintText: AppLocalizations.of(context)!.name,
-                        isInputValid: (s) => s.isNotEmpty,
-                      );
-                    },
-                  );
-                  if (res != null) {
-                    BlocProvider.of<HouseholdUpdateCubit>(context)
-                        .addShoppingList(res);
-                  }
-                },
-              ),
-            ],
-          ),
+              title: Text(AppLocalizations.of(context)!.shoppingLists),
+              actions: [
+                BlocBuilder<HouseholdUpdateCubit, HouseholdUpdateState>(
+                    bloc: BlocProvider.of<HouseholdUpdateCubit>(context),
+                    builder: (context, state) => IconButton(
+                        icon: const Icon(Icons.add),
+                        tooltip: AppLocalizations.of(context)!.addShoppingList,
+                        onPressed: () async {
+                          final res = await getShoppingListName(
+                              context, state.shoppingLists);
+                          if (res != null) {
+                            BlocProvider.of<HouseholdUpdateCubit>(context)
+                                .addShoppingList(res);
+                          }
+                        }))
+              ]),
           SliverCrossAxisConstrained(
             maxCrossAxisExtent: 600,
             child: BlocBuilder<HouseholdUpdateCubit, HouseholdUpdateState>(

--- a/kitchenowl/lib/services/api/shoppinglist.dart
+++ b/kitchenowl/lib/services/api/shoppinglist.dart
@@ -154,6 +154,14 @@ extension ShoppinglistApi on ApiService {
     socket.off("shoppinglist:delete", handler);
   }
 
+  void onShoppinglistUpdate(dynamic Function(dynamic) handler){
+    socket.on("shoppinglist:update", handler);
+  }
+
+  void offShoppinglistUpdate(dynamic Function(dynamic) handler){
+    socket.off("shoppinglist:update", handler);
+  }
+
   void onShoppinglistItemAdd(dynamic Function(dynamic) handler) {
     socket.on("shoppinglist_item:add", handler);
   }

--- a/kitchenowl/lib/widgets/choice_scroll.dart
+++ b/kitchenowl/lib/widgets/choice_scroll.dart
@@ -6,6 +6,7 @@ class ChoiceScroll extends StatefulWidget {
   final IconData? icon;
   final void Function()? onCollapse;
   final List<Widget>? actions;
+  final double paddingLeft;
 
   const ChoiceScroll({
     super.key,
@@ -14,6 +15,7 @@ class ChoiceScroll extends StatefulWidget {
     this.icon,
     this.onCollapse,
     this.actions,
+    this.paddingLeft = 12,
   });
 
   @override
@@ -33,7 +35,7 @@ class _ChoiceScrollState extends State<ChoiceScroll> {
   Widget build(BuildContext context) {
     Widget child = Row(
       children: [
-        const SizedBox(width: 12),
+        SizedBox(width: widget.paddingLeft),
         if (widget.actions != null) ...widget.actions!,
         if (widget.collapsable)
           IconButton(

--- a/kitchenowl/lib/widgets/shopping_list/shopping_list_choice_chip.dart
+++ b/kitchenowl/lib/widgets/shopping_list/shopping_list_choice_chip.dart
@@ -4,14 +4,17 @@ import 'package:kitchenowl/models/shoppinglist.dart';
 class ShoppingListChoiceChip extends StatelessWidget {
   final ShoppingList shoppingList;
   final bool selected;
+  final bool canDelete;
   final void Function(bool)? onSelected;
+  final void Function()? onDeleted;
 
-  const ShoppingListChoiceChip({
-    super.key,
-    required this.shoppingList,
-    this.selected = false,
-    this.onSelected,
-  });
+  const ShoppingListChoiceChip(
+      {super.key,
+      required this.shoppingList,
+      this.canDelete = true,
+      this.selected = false,
+      this.onSelected,
+      this.onDeleted});
 
   @override
   Widget build(BuildContext context) {
@@ -19,22 +22,30 @@ class ShoppingListChoiceChip extends StatelessWidget {
       padding: const EdgeInsets.symmetric(
         horizontal: 4,
       ),
-      child: ChoiceChip(
-        showCheckmark: false,
-        label: Text(
-          shoppingList.name +
-              (shoppingList.items.isNotEmpty
-                  ? " (${shoppingList.items.length})"
-                  : ""),
-          style: TextStyle(
-            color: selected ? Theme.of(context).colorScheme.onPrimary : null,
+      child: Row(children: <Widget>[
+        ChoiceChip(
+          showCheckmark: false,
+          label: Text(
+            shoppingList.name +
+                (shoppingList.items.isNotEmpty
+                    ? " (${shoppingList.items.length})"
+                    : ""),
+            style: TextStyle(
+              color: selected ? Theme.of(context).colorScheme.onPrimary : null,
+            ),
           ),
+          selected: selected,
+          elevation: shoppingList.items.isNotEmpty ? 2 : 0,
+          selectedColor: Theme.of(context).colorScheme.secondary,
+          onSelected: onSelected,
         ),
-        selected: selected,
-        elevation: shoppingList.items.isNotEmpty ? 2 : 0,
-        selectedColor: Theme.of(context).colorScheme.secondary,
-        onSelected: onSelected,
-      ),
+        if (selected && canDelete)
+          IconButton(
+              icon: Icon(Icons.delete, color: Colors.redAccent),
+              onPressed: onDeleted,
+              padding: EdgeInsets.zero,
+              constraints: const BoxConstraints())
+      ]),
     );
   }
 }


### PR DESCRIPTION
This allows users to add and remove shopping lists from the shopping list items page.

Currently adding and removing shopping lists means navigating several menus to be able to do it. Since I have many shopping lists each week that becomes annoying.

![image](https://github.com/user-attachments/assets/a34dc50c-537b-44bc-b2cd-c7665fc5dbcd)

![image](https://github.com/user-attachments/assets/a8e71c05-115c-463c-bd85-185ad63d28fe)

![image](https://github.com/user-attachments/assets/a0d30415-9767-4963-8cff-eecd1aa37960)

![image](https://github.com/user-attachments/assets/e79c5c4b-6fcb-42aa-bf2b-335bc96e1b84)

![image](https://github.com/user-attachments/assets/4f3a269f-8d19-4f60-bd0e-10812f4f16c5)


