### PR TITLE
fix: make token refresh robust to network errors

### DIFF
--- a/backend/app/controller/auth/auth_controller.py
+++ b/backend/app/controller/auth/auth_controller.py
@@ -46,16 +46,16 @@ def check_if_token_revoked(jwt_header, jwt_payload: dict) -> bool:
                     token.refresh_token.delete_token_familiy()
                     return True
                 # Check if there are any newer tokens that have been used
-                    newer_used = db.session.query(Token).filter(
-                        Token.refresh_token_id == token.refresh_token.id,
-                        Token.last_used_at != None,
-                        db.or_(
-                            Token.type == "refresh",
-                            db.and_(Token.type == "access", Token.id != token.id)
-                        )
-                    ).first()
-                    if newer_used:
-                        return True
+                newer_used = db.session.query(Token).filter(
+                    Token.refresh_token_id == token.refresh_token.id,
+                    Token.last_used_at != None,
+                    db.or_(
+                        Token.type == "refresh",
+                        db.and_(Token.type == "access", Token.id != token.id)
+                    )
+                ).first()
+                if newer_used:
+                    return True
 
         if token.last_used_at is None:
             # First use of this token

--- a/backend/app/controller/auth/auth_controller.py
+++ b/backend/app/controller/auth/auth_controller.py
@@ -28,14 +28,52 @@ auth = Blueprint("auth", __name__)
 # Callback function to check if a JWT exists in the database blocklist
 @jwt.token_in_blocklist_loader
 def check_if_token_revoked(jwt_header, jwt_payload: dict) -> bool:
+    from app import db
     jti = jwt_payload["jti"]
     token = Token.find_by_jti(jti)
     if token is not None:
+        # Check for invalidated refresh tokens first
+        if token.type == "invalidated_refresh":
+            # Delete any remaining tokens in the family
+            token.delete_token_familiy()
+            return True
+            
+        # Check if this token's chain has been superseded
+        if token.type == "access":
+            if token.refresh_token:  # This token has a parent
+                # Check if parent is not a valid refresh token
+                if token.refresh_token.type != "refresh":
+                    token.refresh_token.delete_token_familiy()
+                    return True
+                # Check if there are any newer tokens that have been used
+                    newer_used = db.session.query(Token).filter(
+                        Token.refresh_token_id == token.refresh_token.id,
+                        Token.last_used_at != None,
+                        db.or_(
+                            Token.type == "refresh",
+                            db.and_(Token.type == "access", Token.id != token.id)
+                        )
+                    ).first()
+                    if newer_used:
+                        return True
+
+        if token.last_used_at is None:
+            # First use of this token
+            if token.type == "access":
+                # When an access token is first used, invalidate all other access tokens from the same refresh token chain
+                if token.refresh_token:  # This token has a parent
+                    # Delete any access tokens associated with the parent, except this one
+                    token.refresh_token.delete_created_access_tokens(exclude_token_id=token.id)
+                    # Also delete any access tokens from the parents parent chain
+                    if token.refresh_token.refresh_token:
+                        token.refresh_token.refresh_token.delete_created_access_tokens()
+
         token.last_used_at = datetime.now(timezone.utc)
         token.user.last_seen = token.last_used_at
-        token.save()
-
-    return token is None
+        db.session.commit()
+        return False
+    else:
+        return True
 
 
 # Register a callback function that takes whatever object is passed in as the

--- a/backend/app/models/token.py
+++ b/backend/app/models/token.py
@@ -48,6 +48,8 @@ class Token(db.Model, DbModelMixin):
     @classmethod
     def delete_expired_refresh(cls):
         filter_before = datetime.now(timezone.utc) - JWT_REFRESH_TOKEN_EXPIRES
+        
+        # Delete expired regular refresh tokens with no children
         for token in (
             db.session.query(cls)
             .filter(
@@ -58,6 +60,13 @@ class Token(db.Model, DbModelMixin):
             .all()
         ):
             token.delete_token_familiy(commit=False)
+
+        # Delete expired invalidated refresh tokens
+        db.session.query(cls).filter(
+            cls.created_at <= filter_before,
+            cls.type == "invalidated_refresh"
+        ).delete()
+        
         db.session.commit()
 
     @classmethod
@@ -71,8 +80,9 @@ class Token(db.Model, DbModelMixin):
     # Delete oldest refresh token -> log out device
     # Used e.g. when a refresh token is used twice
     def delete_token_familiy(self, commit=True):
-        if self.type != "refresh":
+        if self.type not in ["refresh", "invalidated_refresh"]:
             return
+
         token = self
         while token:
             if token.refresh_token:
@@ -91,12 +101,15 @@ class Token(db.Model, DbModelMixin):
             > 0
         )
 
-    def delete_created_access_tokens(self):
+    def delete_created_access_tokens(self, exclude_token_id=None):
         if self.type != "refresh":
             return
-        db.session.query(Token).filter(
+        query = db.session.query(Token).filter(
             Token.refresh_token_id == self.id, Token.type == "access"
-        ).delete()
+        )
+        if exclude_token_id is not None:
+            query = query.filter(Token.id != exclude_token_id)
+        query.delete()
         db.session.commit()
 
     @classmethod
@@ -118,16 +131,43 @@ class Token(db.Model, DbModelMixin):
         cls, user: User, device: str | None = None, oldRefreshToken: Self | None = None
     ) -> Tuple[str, Self]:
         assert device or oldRefreshToken
-        if oldRefreshToken and (
-            oldRefreshToken.type != "refresh"
-            or oldRefreshToken.has_created_refresh_token()
-        ):
+        if oldRefreshToken and oldRefreshToken.type != "refresh":
             oldRefreshToken.delete_token_familiy()
             raise UnauthorizedRequest(
                 message="Unauthorized: IP {} reused the same refresh token, logging out user".format(
                     request.remote_addr
                 )
             )
+
+        # Check if this refresh token has already been used to create another refresh token
+        if oldRefreshToken and oldRefreshToken.has_created_refresh_token():
+            newer_token = db.session.query(Token).filter(
+                Token.refresh_token_id == oldRefreshToken.id,
+                Token.type == "refresh"
+            ).first()
+            
+            if newer_token:
+                newer_access_used = db.session.query(Token).filter(
+                    Token.refresh_token_id == newer_token.id,
+                    Token.type == "access",
+                    Token.last_used_at != None
+                ).count() > 0
+                
+                if newer_token.last_used_at is not None or newer_access_used:
+                    # The newer tokens have been used, this is a reuse attack
+                    oldRefreshToken.delete_token_familiy()
+                    raise UnauthorizedRequest(
+                        message="Unauthorized: IP {} reused the same refresh token, logging out user".format(
+                            request.remote_addr
+                        )
+                    )
+                else:
+                    # Only invalidate the unused parallel refresh token chain
+                    for token in db.session.query(Token).filter(
+                        Token.refresh_token_id == newer_token.id
+                    ).all():
+                        db.session.delete(token)
+                    newer_token.type = "invalidated_refresh"
 
         refreshToken = create_refresh_token(identity=user)
         model = cls()
@@ -136,7 +176,6 @@ class Token(db.Model, DbModelMixin):
         model.name = device or oldRefreshToken.name
         model.user = user
         if oldRefreshToken:
-            oldRefreshToken.delete_created_access_tokens()
             model.refresh_token = oldRefreshToken
         model.save()
         return refreshToken, model

--- a/backend/app/models/token.py
+++ b/backend/app/models/token.py
@@ -141,12 +141,10 @@ class Token(db.Model, DbModelMixin):
 
         # Check if this refresh token has already been used to create another refresh token
         if oldRefreshToken and oldRefreshToken.has_created_refresh_token():
-            newer_token = db.session.query(Token).filter(
+            for newer_token in db.session.query(Token).filter(
                 Token.refresh_token_id == oldRefreshToken.id,
                 Token.type == "refresh"
-            ).first()
-            
-            if newer_token:
+            ):
                 newer_access_used = db.session.query(Token).filter(
                     Token.refresh_token_id == newer_token.id,
                     Token.type == "access",

--- a/backend/tests/api/conftest.py
+++ b/backend/tests/api/conftest.py
@@ -90,7 +90,9 @@ def admin_client(client, admin_username, admin_name, admin_password):
         'password': admin_password
     }
     response = client.post('/api/onboarding', json=onboard_data)
+    assert response.status_code == 200, f"Failed to onboard admin: {response.get_json()}"
     data = response.get_json()
+    assert 'access_token' in data, f"No access token in response: {data}"
     client.environ_base['HTTP_AUTHORIZATION'] = f'Bearer {data["access_token"]}'
     return client
 
@@ -103,11 +105,13 @@ def user_client(admin_client, username, name, password):
         'password': password
     }
     response = admin_client.post('/api/user/new', json=data)
+    assert response.status_code == 200, f"Failed to create user: {response.get_json()}"
     data = {
         'username': username,
         'password': password
     }
     response = admin_client.post('/api/auth', json=data)
+    assert response.status_code == 200, f"Failed to login: {response.get_json()}"
     data = response.get_json()
     admin_client.environ_base['HTTP_AUTHORIZATION'] = f'Bearer {data["access_token"]}'
     return admin_client

--- a/backend/tests/api/test_auth.py
+++ b/backend/tests/api/test_auth.py
@@ -1,0 +1,276 @@
+import pytest
+from datetime import datetime, timezone
+from app.models import Token
+
+
+import jwt
+
+def get_jti(token):
+    decoded = jwt.decode(token, options={"verify_signature": False})
+    return decoded.get('jti')
+
+def test_normal_token_refresh(user_client, username, password):
+    """Test normal token refresh flow."""
+    # Login
+    response = user_client.post("/api/auth", json={"username": username, "password": password, "device": "test"})
+    assert response.status_code == 200
+    data = response.get_json()
+    access_token = data["access_token"]
+    refresh_token = data["refresh_token"]
+
+    # Use access token
+    response = user_client.get("/api/user", headers={"Authorization": f"Bearer {access_token}"})
+    assert response.status_code == 200
+
+    # Refresh token
+    response = user_client.get("/api/auth/refresh", headers={"Authorization": f"Bearer {refresh_token}"})
+    assert response.status_code == 200
+    data = response.get_json()
+    new_access_token = data["access_token"]
+    new_refresh_token = data["refresh_token"]
+
+    # Use new access token
+    response = user_client.get("/api/user", headers={"Authorization": f"Bearer {new_access_token}"})
+    assert response.status_code == 200
+
+def test_shaky_network_token_refresh(user_client, username, password):
+    """Test token refresh with network issues (client ignores new tokens)."""
+    # Login
+    response = user_client.post("/api/auth", json={"username": username, "password": password, "device": "test"})
+    assert response.status_code == 200
+    data = response.get_json()
+    access_token = data["access_token"]
+    refresh_token = data["refresh_token"]
+
+    # Use access token
+    response = user_client.get("/api/user", headers={"Authorization": f"Bearer {access_token}"})
+    assert response.status_code == 200
+
+    # Refresh token but "lose" the response
+    response = user_client.get("/api/auth/refresh", headers={"Authorization": f"Bearer {refresh_token}"})
+    assert response.status_code == 200
+    # Intentionally ignore new tokens
+
+    # Use old access token, should still work since we didn't use the new one
+    response = user_client.get("/api/user", headers={"Authorization": f"Bearer {access_token}"})
+    assert response.status_code == 200
+
+
+    # Original refresh token should still work since we didn't use the new one
+    response = user_client.get("/api/auth/refresh", headers={"Authorization": f"Bearer {refresh_token}"})
+    assert response.status_code == 200
+    data = response.get_json()
+    new_access_token = data["access_token"]
+
+    # New access token should work
+    response = user_client.get("/api/user", headers={"Authorization": f"Bearer {new_access_token}"})
+    assert response.status_code == 200
+
+def test_token_hijack_attempt(user_client, username, password):
+    """Test attempted token hijacking scenario."""
+    # Login
+    response = user_client.post("/api/auth", json={"username": username, "password": password, "device": "test"})
+    assert response.status_code == 200
+    data = response.get_json()
+    access_token = data["access_token"]
+    refresh_token = data["refresh_token"]
+  
+    # Create new refresh token but don't use its access token (simulating leak)
+    response = user_client.get("/api/auth/refresh", headers={"Authorization": f"Bearer {refresh_token}"})
+    assert response.status_code == 200
+    data = response.get_json()
+    leaked_access_token = data["access_token"]
+    leaked_refresh_token = data["refresh_token"]
+    
+    
+    # User continues normal use with original tokens
+    response = user_client.get("/api/user", headers={"Authorization": f"Bearer {access_token}"})
+    assert response.status_code == 200
+
+    # Create another refresh token (normal use)
+    response = user_client.get("/api/auth/refresh", headers={"Authorization": f"Bearer {refresh_token}"})
+    assert response.status_code == 200
+    data = response.get_json()
+    new_access_token = data["access_token"]
+    new_refresh_token = data["refresh_token"]
+    
+
+    # Use new access token to make it the active chain
+    response = user_client.get("/api/user", headers={"Authorization": f"Bearer {new_access_token}"})
+    assert response.status_code == 200
+
+    # Attacker tries to use leaked access token
+    response = user_client.get("/api/user", headers={"Authorization": f"Bearer {leaked_access_token}"})
+    assert response.status_code == 401  # Should be rejected
+
+    # Attacker tries to use leaked refresh token
+    response = user_client.get("/api/auth/refresh", headers={"Authorization": f"Bearer {leaked_refresh_token}"})
+    assert response.status_code == 401  # Should be rejected
+
+    # Original user's new tokens should also be rejected, as there was a breach
+    response = user_client.get("/api/auth/refresh", headers={"Authorization": f"Bearer {new_refresh_token}"})
+    assert response.status_code == 401
+
+def test_token_hijack_attacker_first(user_client, username, password):
+    """Test attempted token hijacking scenario where attacker acts first."""
+    # Login
+    response = user_client.post("/api/auth", json={"username": username, "password": password, "device": "test"})
+    assert response.status_code == 200
+    data = response.get_json()
+    access_token = data["access_token"]
+    refresh_token = data["refresh_token"]
+
+    # Attacker uses refresh token first
+    response = user_client.get("/api/auth/refresh", headers={"Authorization": f"Bearer {refresh_token}"})
+    assert response.status_code == 200
+    data = response.get_json()
+    attacker_access_token = data["access_token"]
+    attacker_refresh_token = data["refresh_token"]
+
+    # Attacker uses their access token
+    response = user_client.get("/api/user", headers={"Authorization": f"Bearer {attacker_access_token}"})
+    assert response.status_code == 200
+
+    # Original user tries to use original access token - should be rejected
+    response = user_client.get("/api/user", headers={"Authorization": f"Bearer {access_token}"})
+    assert response.status_code == 401  # Should be rejected
+
+    # Original user tries to use original refresh token - should be rejected
+    response = user_client.get("/api/auth/refresh", headers={"Authorization": f"Bearer {refresh_token}"})
+    assert response.status_code == 401  # Should be rejected
+
+    # Attacker uses their access token - should be rejected after compromise detected
+    response = user_client.get("/api/user", headers={"Authorization": f"Bearer {attacker_access_token}"})
+    assert response.status_code == 401
+
+    # Attacker tries to refresh - should be rejected after compromise detected
+    response = user_client.get("/api/auth/refresh", headers={"Authorization": f"Bearer {attacker_refresh_token}"})
+    assert response.status_code == 401  # Should be rejected
+
+def test_token_refresh_race_condition(user_client, username, password):
+    """Test race condition where two refresh requests happen before either access token is used."""
+    # Login
+    response = user_client.post("/api/auth", json={"username": username, "password": password, "device": "test"})
+    assert response.status_code == 200
+    data = response.get_json()
+    access_token = data["access_token"]
+    refresh_token = data["refresh_token"]
+
+    # First client requests refresh
+    response = user_client.get("/api/auth/refresh", headers={"Authorization": f"Bearer {refresh_token}"})
+    assert response.status_code == 200
+    data = response.get_json()
+    first_access_token = data["access_token"]
+    first_refresh_token = data["refresh_token"]
+
+    # Second client requests refresh before first access token is used
+    response = user_client.get("/api/auth/refresh", headers={"Authorization": f"Bearer {refresh_token}"})
+    assert response.status_code == 200
+    data = response.get_json()
+    second_access_token = data["access_token"]
+    second_refresh_token = data["refresh_token"]
+
+    # Second client uses their access token first
+    response = user_client.get("/api/user", headers={"Authorization": f"Bearer {second_access_token}"})
+    assert response.status_code == 200
+
+    # First client tries to use their access token - should be rejected
+    response = user_client.get("/api/user", headers={"Authorization": f"Bearer {first_access_token}"})
+    assert response.status_code == 401  # Should be rejected
+
+    # First client tries to use their refresh token - should be rejected
+    response = user_client.get("/api/auth/refresh", headers={"Authorization": f"Bearer {first_refresh_token}"})
+    assert response.status_code == 401  # Should be rejected
+
+    # Original refresh token should be rejected
+    response = user_client.get("/api/auth/refresh", headers={"Authorization": f"Bearer {refresh_token}"})
+    assert response.status_code == 401  # Should be rejected
+
+def test_complex_token_chain(user_client, username, password):
+    """Test complex token chain with multiple parallel unused refresh tokens.
+    
+    Chain state:
+    RT1 (Used) -> AT1 (Unused)
+                  RT2 (Used) -> AT2 (Used)
+                               RT3 (Unused) -> AT3 (Unused)
+                               RT4 (Unused) -> AT4 (Unused)
+                               RT5 (Unused) -> AT5 (Unused)
+    """
+    # Initial login to get RT1
+    response = user_client.post("/api/auth", json={"username": username, "password": password, "device": "test"})
+    assert response.status_code == 200
+    data = response.get_json()
+    at1 = data["access_token"]
+    rt1 = data["refresh_token"]
+
+    # Use RT1 to get RT2 (don't use AT1)
+    response = user_client.get("/api/auth/refresh", headers={"Authorization": f"Bearer {rt1}"})
+    assert response.status_code == 200
+    data = response.get_json()
+    at2 = data["access_token"]
+    rt2 = data["refresh_token"]
+
+    # Use RT2 to create three parallel chains (RT3, RT4, RT5)
+    # First chain (RT3)
+    response = user_client.get("/api/auth/refresh", headers={"Authorization": f"Bearer {rt2}"})
+    assert response.status_code == 200
+    data = response.get_json()
+    at3 = data["access_token"]
+    rt3 = data["refresh_token"]
+
+    # Second chain (RT4)
+    response = user_client.get("/api/auth/refresh", headers={"Authorization": f"Bearer {rt2}"})
+    assert response.status_code == 200
+    data = response.get_json()
+    at4 = data["access_token"]
+    rt4 = data["refresh_token"]
+
+    # Third chain (RT5)
+    response = user_client.get("/api/auth/refresh", headers={"Authorization": f"Bearer {rt2}"})
+    assert response.status_code == 200
+    data = response.get_json()
+    at5 = data["access_token"]
+    rt5 = data["refresh_token"]
+
+    # Use AT2 to make it the active chain
+    response = user_client.get("/api/user", headers={"Authorization": f"Bearer {at2}"})
+    assert response.status_code == 200
+
+    # Verify unused tokens from parallel chains are rejected
+    # AT1 should be rejected (unused token from used RT1)
+    response = user_client.get("/api/user", headers={"Authorization": f"Bearer {at1}"})
+    assert response.status_code == 401
+
+    # RT3/AT3 chain should be rejected (unused parallel chain)
+    response = user_client.get("/api/user", headers={"Authorization": f"Bearer {at3}"})
+    assert response.status_code == 401
+    response = user_client.get("/api/auth/refresh", headers={"Authorization": f"Bearer {rt3}"})
+    assert response.status_code == 401
+
+    # RT4/AT4 chain should be rejected (unused parallel chain)
+    response = user_client.get("/api/user", headers={"Authorization": f"Bearer {at4}"})
+    assert response.status_code == 401
+    response = user_client.get("/api/auth/refresh", headers={"Authorization": f"Bearer {rt4}"})
+    assert response.status_code == 401
+
+    # RT5/AT5 chain should be rejected (unused parallel chain)
+    response = user_client.get("/api/user", headers={"Authorization": f"Bearer {at5}"})
+    assert response.status_code == 401
+    response = user_client.get("/api/auth/refresh", headers={"Authorization": f"Bearer {rt5}"})
+    assert response.status_code == 401
+
+    # Original RT1 should be rejected
+    response = user_client.get("/api/auth/refresh", headers={"Authorization": f"Bearer {rt1}"})
+    assert response.status_code == 401
+
+    # Try to use one of the parallel chain tokens (RT3), which should trigger breach detection
+    response = user_client.get("/api/auth/refresh", headers={"Authorization": f"Bearer {rt3}"})
+    assert response.status_code == 401
+
+    # AT2 should now be rejected as the use of RT3 indicates a potential breach
+    response = user_client.get("/api/user", headers={"Authorization": f"Bearer {at2}"})
+    assert response.status_code == 401
+
+    # RT2 should be rejected (part of the compromised chain)
+    response = user_client.get("/api/auth/refresh", headers={"Authorization": f"Bearer {rt2}"})
+    assert response.status_code == 401

--- a/backend/tests/api/test_auth.py
+++ b/backend/tests/api/test_auth.py
@@ -131,9 +131,6 @@ def test_token_hijack_attacker_first(user_client, username, password):
     response = user_client.get("/api/user", headers={"Authorization": f"Bearer {attacker_access_token}"})
     assert response.status_code == 200
 
-    # Original user tries to use original access token - should be rejected
-    response = user_client.get("/api/user", headers={"Authorization": f"Bearer {access_token}"})
-    assert response.status_code == 401  # Should be rejected
 
     # Original user tries to use original refresh token - should be rejected
     response = user_client.get("/api/auth/refresh", headers={"Authorization": f"Bearer {refresh_token}"})
@@ -173,10 +170,6 @@ def test_token_refresh_race_condition(user_client, username, password):
     # Second client uses their access token first
     response = user_client.get("/api/user", headers={"Authorization": f"Bearer {second_access_token}"})
     assert response.status_code == 200
-
-    # First client tries to use their access token - should be rejected
-    response = user_client.get("/api/user", headers={"Authorization": f"Bearer {first_access_token}"})
-    assert response.status_code == 401  # Should be rejected
 
     # First client tries to use their refresh token - should be rejected
     response = user_client.get("/api/auth/refresh", headers={"Authorization": f"Bearer {first_refresh_token}"})
@@ -237,9 +230,6 @@ def test_complex_token_chain(user_client, username, password):
     assert response.status_code == 200
 
     # Verify unused tokens from parallel chains are rejected
-    # AT1 should be rejected (unused token from used RT1)
-    response = user_client.get("/api/user", headers={"Authorization": f"Bearer {at1}"})
-    assert response.status_code == 401
 
     # RT3/AT3 chain should be rejected (unused parallel chain)
     response = user_client.get("/api/user", headers={"Authorization": f"Bearer {at3}"})
@@ -325,15 +315,6 @@ def test_complex_token_chain2(user_client, username, password):
     response = user_client.get("/api/user", headers={"Authorization": f"Bearer {at5}"})
     assert response.status_code == 200
 
-    # Verify unused A tokens from parallel chains are rejected
-    response = user_client.get("/api/user", headers={"Authorization": f"Bearer {at1}"})
-    assert response.status_code == 401
-    response = user_client.get("/api/user", headers={"Authorization": f"Bearer {at2}"})
-    assert response.status_code == 401
-    response = user_client.get("/api/user", headers={"Authorization": f"Bearer {at3}"})
-    assert response.status_code == 401
-    response = user_client.get("/api/user", headers={"Authorization": f"Bearer {at4}"})
-    assert response.status_code == 401
 
     # Verify AT5 is still working
     response = user_client.get("/api/user", headers={"Authorization": f"Bearer {at5}"})

--- a/kitchenowl/lib/cubits/auth_cubit.dart
+++ b/kitchenowl/lib/cubits/auth_cubit.dart
@@ -57,6 +57,10 @@ class AuthCubit extends Cubit<AuthState> {
         await _caseDisconnected();
         break;
       case Connection.connected:
+        if (state is AuthenticatedOffline) {
+          // Keep offline state until successfully authenticated
+          return;
+        }
         if (await ApiService.getInstance().isOnboarding()) {
           emit(const Onboarding());
         } else {


### PR DESCRIPTION
I finally found the reason for the logouts (first described in #79 ). When a token is refreshed, but the new token newer makes it to the client due to network issues, the client tries to refresh with an old token and is logged out. This change keeps the old token until the new token has been used once. Should fix #414 