### PR TITLE
fix: prevent incorrect offline->online transitions without successful…

### DIFF
--- a/kitchenowl/lib/cubits/auth_cubit.dart
+++ b/kitchenowl/lib/cubits/auth_cubit.dart
@@ -58,7 +58,15 @@ class AuthCubit extends Cubit<AuthState> {
         break;
       case Connection.connected:
         if (state is AuthenticatedOffline) {
-          // Keep offline state until successfully authenticated
+          // Try to authenticate, only stay offline if it fails
+          try {
+            if (await ApiService.getInstance().refreshAuth()) {
+              final user = (await ApiService.getInstance().getUser())!;
+              emit(Authenticated(user));
+            }
+          } catch (_) {
+            // Stay offline if auth fails
+          }
           return;
         }
         if (await ApiService.getInstance().isOnboarding()) {


### PR DESCRIPTION
While testing #610 I found a race condition that sometimes logs the user out when coming out of offline mode when the network is bad. #610 and this should fix #414 for good.