### PR TITLE
Sort planner by weekday relative to the current day

### DIFF
--- a/kitchenowl/lib/l10n/app_de.arb
+++ b/kitchenowl/lib/l10n/app_de.arb
@@ -658,5 +658,7 @@
   "yearly": "Jährlich",
   "yes": "Ja",
   "yields": "Portionen",
-  "you": "du"
+  "you": "du",
+  "today": "Heute",
+  "tomorrow": "Morgen"
 }

--- a/kitchenowl/lib/l10n/app_de.arb
+++ b/kitchenowl/lib/l10n/app_de.arb
@@ -341,6 +341,8 @@
   "@themeLight": {},
   "@themeMode": {},
   "@themeSystem": {},
+  "@today": {},
+  "@tomorrow": {},
   "@total": {},
   "@totalTime": {},
   "@tutorialItemDescription1": {},
@@ -624,6 +626,8 @@
   "themeLight": "Hell",
   "themeMode": "Farbschema",
   "themeSystem": "System",
+  "today": "Heute",
+  "tomorrow": "Morgen",
   "total": "Gesamt",
   "totalTime": "Gesamtzeit",
   "tutorialItemDescription1": "Bei der Suche nach Artikeln kannst du mit einer Menge anfangen, die dann als Beschreibung hinzugefügt wird.",
@@ -658,7 +662,5 @@
   "yearly": "Jährlich",
   "yes": "Ja",
   "yields": "Portionen",
-  "you": "du",
-  "today": "Heute",
-  "tomorrow": "Morgen"
+  "you": "du"
 }

--- a/kitchenowl/lib/l10n/app_en.arb
+++ b/kitchenowl/lib/l10n/app_en.arb
@@ -343,6 +343,8 @@
   "@themeLight": {},
   "@themeMode": {},
   "@themeSystem": {},
+  "@today": {},
+  "@tomorrow": {},
   "@total": {},
   "@totalTime": {},
   "@tutorialItemDescription1": {},
@@ -626,6 +628,8 @@
   "themeLight": "Light",
   "themeMode": "Theme",
   "themeSystem": "System",
+  "today": "Today",
+  "tomorrow": "Tomorrow",
   "total": "Total",
   "totalTime": "Total time",
   "tutorialItemDescription1": "When searching for items, you can add an amount at the start of your query, and it will be added as a description.",
@@ -660,7 +664,5 @@
   "yearly": "Yearly",
   "yes": "Yes",
   "yields": "Yields",
-  "you": "you",
-  "today": "Today",
-  "tomorrow": "Tomorrow"
+  "you": "you"
 }

--- a/kitchenowl/lib/l10n/app_en.arb
+++ b/kitchenowl/lib/l10n/app_en.arb
@@ -660,5 +660,7 @@
   "yearly": "Yearly",
   "yes": "Yes",
   "yields": "Yields",
-  "you": "you"
+  "you": "you",
+  "today": "Today",
+  "tomorrow": "Tomorrow"
 }

--- a/kitchenowl/lib/l10n/app_es.arb
+++ b/kitchenowl/lib/l10n/app_es.arb
@@ -341,6 +341,8 @@
   "@themeLight": {},
   "@themeMode": {},
   "@themeSystem": {},
+  "@today": {},
+  "@tomorrow": {},
   "@total": {},
   "@totalTime": {},
   "@tutorialItemDescription1": {},
@@ -624,6 +626,8 @@
   "themeLight": "Claro",
   "themeMode": "Tema",
   "themeSystem": "Sistema",
+  "today": "Hoy",
+  "tomorrow": "Mañana",
   "total": "Total",
   "totalTime": "Tiempo total",
   "tutorialItemDescription1": "Al buscar artículos, puede añadir una cantidad al principio de la consulta, y se añadirá como descripción.",
@@ -658,7 +662,5 @@
   "yearly": "Anualmente",
   "yes": "Sí",
   "yields": "Raciones",
-  "you": "tu",
-  "today": "Hoy",
-  "tomorrow": "Mañana"
+  "you": "tu"
 }

--- a/kitchenowl/lib/l10n/app_es.arb
+++ b/kitchenowl/lib/l10n/app_es.arb
@@ -658,5 +658,7 @@
   "yearly": "Anualmente",
   "yes": "Sí",
   "yields": "Raciones",
-  "you": "tu"
+  "you": "tu",
+  "today": "Hoy",
+  "tomorrow": "Mañana"
 }

--- a/kitchenowl/lib/pages/household_page/planner.dart
+++ b/kitchenowl/lib/pages/household_page/planner.dart
@@ -22,6 +22,26 @@ int db_weekday(int shift) {
   return DateTime.now().add(Duration(days: shift)).weekday - 1;
 }
 
+String formatDateAsWeekday(DateTime date, BuildContext context,
+    {String default_format = 'EEEE'}) {
+  DateTime today = DateTime.now();
+  DateTime tomorrow = today.add(Duration(days: 1));
+
+  // Check if the date is today or tomorrow
+  if (date.year == today.year &&
+      date.month == today.month &&
+      date.day == today.day) {
+    return AppLocalizations.of(context)!.today;
+  } else if (date.year == tomorrow.year &&
+      date.month == tomorrow.month &&
+      date.day == tomorrow.day) {
+    return AppLocalizations.of(context)!.tomorrow;
+  } else {
+    // Return the weekday name
+    return DateFormat(default_format).format(date);
+  }
+}
+
 class PlannerPage extends StatefulWidget {
   const PlannerPage({super.key});
 
@@ -191,7 +211,7 @@ class _PlannerPageState extends State<PlannerPage> {
                                           padding:
                                               const EdgeInsets.only(top: 5),
                                           child: Text(
-                                            '${DateFormat.E().format(DateTime.now().add(Duration(days: i)))}',
+                                            '${formatDateAsWeekday(DateTime.now().add(Duration(days: i)), context, default_format: 'E')}',
                                             style: Theme.of(context)
                                                 .textTheme
                                                 .bodyLarge,
@@ -399,7 +419,9 @@ class _PlannerPageState extends State<PlannerPage> {
         cancelText: AppLocalizations.of(context)!.cancel,
         options: List.generate(7, (index) {
           return SelectDialogOption(
-              db_weekday(index), DateFormat.EEEE().format(DateTime.now().add(Duration(days: index))));
+              db_weekday(index),
+              formatDateAsWeekday(
+                  DateTime.now().add(Duration(days: index)), context));
         }),
       ),
     );

--- a/kitchenowl/lib/pages/household_page/planner.dart
+++ b/kitchenowl/lib/pages/household_page/planner.dart
@@ -17,6 +17,11 @@ import 'package:kitchenowl/widgets/recipe_card.dart';
 import 'package:responsive_builder/responsive_builder.dart';
 import 'package:tuple/tuple.dart';
 
+int db_weekday(int shift) {
+  // subtract 1 because DateTime.weekday goes from 1 to 7. Kitchenowl-db from 0 to 6
+  return DateTime.now().add(Duration(days: shift)).weekday - 1;
+}
+
 class PlannerPage extends StatefulWidget {
   const PlannerPage({super.key});
 
@@ -42,16 +47,6 @@ class _PlannerPageState extends State<PlannerPage> {
   Widget build(BuildContext context) {
     final cubit = BlocProvider.of<PlannerCubit>(context);
     final household = BlocProvider.of<HouseholdCubit>(context).state.household;
-
-    final weekdayMapping = {
-      0: DateTime.monday,
-      1: DateTime.tuesday,
-      2: DateTime.wednesday,
-      3: DateTime.thursday,
-      4: DateTime.friday,
-      5: DateTime.saturday,
-      6: DateTime.sunday,
-    };
 
     return SafeArea(
       child: Scrollbar(
@@ -172,8 +167,9 @@ class _PlannerPageState extends State<PlannerPage> {
                                   ),
                                 ),
                               ),
-                            for (int day = 0; day < 7; day++)
-                              for (final plan in state.getPlannedOfDay(day))
+                            for (int i = 0; i < 7; i++)
+                              for (final plan
+                                  in state.getPlannedOfDay(db_weekday(i)))
                                 KitchenOwlFractionallySizedBox(
                                   widthFactor: (1 /
                                       DynamicStyling.itemCrossAxisCount(
@@ -188,12 +184,14 @@ class _PlannerPageState extends State<PlannerPage> {
                                     crossAxisAlignment:
                                         CrossAxisAlignment.stretch,
                                     children: [
-                                      if (plan == state.getPlannedOfDay(day)[0])
+                                      if (plan ==
+                                          state.getPlannedOfDay(
+                                              db_weekday(i))[0])
                                         Padding(
                                           padding:
                                               const EdgeInsets.only(top: 5),
                                           child: Text(
-                                            '${DateFormat.E().dateSymbols.STANDALONEWEEKDAYS[weekdayMapping[day]! % 7]}:',
+                                            '${DateFormat.E().format(DateTime.now().add(Duration(days: i)))}',
                                             style: Theme.of(context)
                                                 .textTheme
                                                 .bodyLarge,
@@ -211,7 +209,7 @@ class _PlannerPageState extends State<PlannerPage> {
                                           onPressed: () {
                                             cubit.remove(
                                               plan.recipe,
-                                              day,
+                                              db_weekday(i),
                                             );
                                           },
                                           onLongPressed: () => _openRecipePage(
@@ -394,28 +392,15 @@ class _PlannerPageState extends State<PlannerPage> {
     PlannerCubit cubit,
     Recipe recipe,
   ) async {
-    final weekdayMapping = {
-      0: DateTime.monday,
-      1: DateTime.tuesday,
-      2: DateTime.wednesday,
-      3: DateTime.thursday,
-      4: DateTime.friday,
-      5: DateTime.saturday,
-      6: DateTime.sunday,
-    };
     int? day = await showDialog<int>(
       context: context,
       builder: (context) => SelectDialog(
         title: AppLocalizations.of(context)!.addRecipeToPlannerShort,
         cancelText: AppLocalizations.of(context)!.cancel,
-        options: weekdayMapping.entries
-            .map(
-              (e) => SelectDialogOption(
-                e.key,
-                DateFormat.E().dateSymbols.STANDALONEWEEKDAYS[e.value % 7],
-              ),
-            )
-            .toList(),
+        options: List.generate(7, (index) {
+          return SelectDialogOption(
+              db_weekday(index), DateFormat.EEEE().format(DateTime.now().add(Duration(days: index))));
+        }),
       ),
     );
     if (day != null) {

--- a/kitchenowl/lib/pages/recipe_page.dart
+++ b/kitchenowl/lib/pages/recipe_page.dart
@@ -19,6 +19,11 @@ import 'package:responsive_builder/responsive_builder.dart';
 import 'package:sliver_tools/sliver_tools.dart';
 import 'package:tuple/tuple.dart';
 
+int db_weekday(int shift) {
+  // subtract 1 because DateTime.weekday goes from 1 to 7. Kitchenowl-db from 0 to 6
+  return DateTime.now().add(Duration(days: shift)).weekday - 1;
+}
+
 class RecipePage extends StatefulWidget {
   final Household? household;
   final Recipe recipe;
@@ -339,15 +344,6 @@ class _RecipePageState extends State<RecipePage> {
                             LoadingElevatedButton(
                               child: const Icon(Icons.calendar_month_rounded),
                               onPressed: () async {
-                                final weekdayMapping = {
-                                  0: DateTime.monday,
-                                  1: DateTime.tuesday,
-                                  2: DateTime.wednesday,
-                                  3: DateTime.thursday,
-                                  4: DateTime.friday,
-                                  5: DateTime.saturday,
-                                  6: DateTime.sunday,
-                                };
                                 int? day = await showDialog<int>(
                                   context: context,
                                   builder: (context) => SelectDialog(
@@ -355,17 +351,13 @@ class _RecipePageState extends State<RecipePage> {
                                         .addRecipeToPlannerShort,
                                     cancelText:
                                         AppLocalizations.of(context)!.cancel,
-                                    options: weekdayMapping.entries
-                                        .map(
-                                          (e) => SelectDialogOption(
-                                            e.key,
-                                            DateFormat.E()
-                                                    .dateSymbols
-                                                    .STANDALONEWEEKDAYS[
-                                                e.value % 7],
-                                          ),
-                                        )
-                                        .toList(),
+                                    options: List.generate(7, (index) {
+                                      return SelectDialogOption(
+                                          db_weekday(index),
+                                          DateFormat.EEEE().format(
+                                              DateTime.now()
+                                                  .add(Duration(days: index))));
+                                    }),
                                   ),
                                 );
                                 if (day != null) {

--- a/kitchenowl/lib/pages/recipe_page.dart
+++ b/kitchenowl/lib/pages/recipe_page.dart
@@ -24,6 +24,26 @@ int db_weekday(int shift) {
   return DateTime.now().add(Duration(days: shift)).weekday - 1;
 }
 
+String formatDateAsWeekday(DateTime date, BuildContext context,
+    {String default_format = 'EEEE'}) {
+  DateTime today = DateTime.now();
+  DateTime tomorrow = today.add(Duration(days: 1));
+
+  // Check if the date is today or tomorrow
+  if (date.year == today.year &&
+      date.month == today.month &&
+      date.day == today.day) {
+    return AppLocalizations.of(context)!.today;
+  } else if (date.year == tomorrow.year &&
+      date.month == tomorrow.month &&
+      date.day == tomorrow.day) {
+    return AppLocalizations.of(context)!.tomorrow;
+  } else {
+    // Return the weekday name
+    return DateFormat(default_format).format(date);
+  }
+}
+
 class RecipePage extends StatefulWidget {
   final Household? household;
   final Recipe recipe;
@@ -354,9 +374,10 @@ class _RecipePageState extends State<RecipePage> {
                                     options: List.generate(7, (index) {
                                       return SelectDialogOption(
                                           db_weekday(index),
-                                          DateFormat.EEEE().format(
+                                          formatDateAsWeekday(
                                               DateTime.now()
-                                                  .add(Duration(days: index))));
+                                                  .add(Duration(days: index)),
+                                              context));
                                     }),
                                   ),
                                 );


### PR DESCRIPTION
Orders the "add-to-planner" by weekdays and replaces weekdays by "Today" and "Tomorrow", if it applies.

I'm aware that if you add a recipe for "today", it will switch to "wednesday" for example the next day. But this is nothing different than before I think.

