### PR TITLE
Feature: replace recipe searching with fuzzywuzzy search on local recipes

### DIFF
--- a/kitchenowl/pubspec.lock
+++ b/kitchenowl/pubspec.lock
@@ -487,6 +487,14 @@ packages:
     description: flutter
     source: sdk
     version: "0.0.0"
+  fuzzywuzzy:
+    dependency: "direct main"
+    description:
+      name: fuzzywuzzy
+      sha256: "3004379ffd6e7f476a0c2091f38f16588dc45f67de7adf7c41aa85dec06b432c"
+      url: "https://pub.dev"
+    source: hosted
+    version: "1.2.0"
   go_router:
     dependency: "direct main"
     description:

--- a/kitchenowl/pubspec.yaml
+++ b/kitchenowl/pubspec.yaml
@@ -74,6 +74,7 @@ dependencies:
   universal_html: ^2.2.4
   sign_in_with_apple: ^6.0.0
   wakelock_plus: ^1.2.10
+  fuzzywuzzy: ^1.2.0
 
 dev_dependencies:
   flutter_test:


### PR DESCRIPTION
Use fuzzywuzzy search to rank recipes when searching. The searching always runs on the local recipe data. 

- [ ] This probably makes the recipe search API endpoint in the backend never be used. So one could also remove that endpoint