### PR TITLE
fix: Expense overview - Total for selected month is colored opposite than it should be

### DIFF
--- a/kitchenowl/lib/pages/expense_overview_page.dart
+++ b/kitchenowl/lib/pages/expense_overview_page.dart
@@ -185,10 +185,10 @@ class _ExpenseOverviewPageState extends State<ExpenseOverviewPage> {
                                       .titleLarge
                                       ?.copyWith(
                                         color: totalForSelectedMonth < 0
-                                            ? Theme.of(context)
+                                            ? AppColors.green
+                                            : Theme.of(context)
                                                 .colorScheme
-                                                .error
-                                            : AppColors.green,
+                                                .error,
                                       ),
                                 ),
                                 if (state


### PR DESCRIPTION
Fixed total for selected month being colored opposite than it should

Closes #730 