### PR TITLE
change comment for better unstanding

### DIFF
--- a/docs/docs/self-hosting/oidc.md
+++ b/docs/docs/self-hosting/oidc.md
@@ -82,7 +82,7 @@ Place this in your Authelia [configuration.yaml](https://www.authelia.com/config
         - email
         - profile
     redirect_uris:
-        - https://your.domain.here/signin/redirect # Put the same value as FRONT_URL, appended with /signin/redirect
+        - https://your.domain.here/signin/redirect # In FRONT_URL, do not append "/signin/redirect"
         - kitchenowl:///signin/redirect
     response_modes:
     userinfo_signing_algorithm: none


### PR DESCRIPTION
I misunderstood the comment after request_uri and unintentionally appended /signing/redirect to the FRONT_URL.
This leads to a authelia redirect error.
Maybe someone else has the same issue and changing the comment could prevent that.