### PR TITLE
Use proper URI format for OIDC redirect

### DIFF
--- a/backend/app/controller/auth/auth_controller.py
+++ b/backend/app/controller/auth/auth_controller.py
@@ -236,7 +236,7 @@ if FRONT_URL and len(oidc_clients) > 0:
         state = rndstr()
         nonce = rndstr()
         redirect_uri = (
-            "kitchenowl://"
+            "kitchenowl:"
             if "kitchenowl_scheme" in args and args["kitchenowl_scheme"]
             else FRONT_URL
         ) + "/signin/redirect"

--- a/docs/docs/self-hosting/oidc.md
+++ b/docs/docs/self-hosting/oidc.md
@@ -9,7 +9,7 @@ Inside your OIDC you need to configure a new client, with the following to redir
 
 <div class="annotate" markdown>
 - `FRONT_URL(1)/signin/redirect` 
-- `kitchenowl:///signin/redirect`
+- `kitchenowl:/signin/redirect`
 </div>
 
 1. FRONT_URL is the environment variable that exactly matches KitchenOwl's URL including the schema (e.g. `https://app.kitchenowl.org`)


### PR DESCRIPTION
Use kitchenowl:/signin/redirect instead of kitchenowl:///signin/redirect for the OIDC login redirect. This works with the existing app, better conforms to RFC 3986, and fixes OIDC login with Keycloak.

I've tested this on my personal instance which uses Keycloak, and on both desktop browser and the Android app.

Fixes #644