### PR TITLE
Fix: Database Container Allows Unauthorized Permission Escalation in docker-compose-postgres.yml

### DIFF
--- a/docker-compose-postgres.yml
+++ b/docker-compose-postgres.yml
@@ -2,6 +2,8 @@ version: "3"
 services:
   db:
     image: postgres:15
+    security_opt:
+      - "no-new-privileges:true"
     restart: unless-stopped
     environment:
       POSTGRES_DB: kitchenowl


### PR DESCRIPTION
**Context and Purpose:**

This PR automatically remediates a security vulnerability:
- **Description:** Service 'db' allows for privilege escalation via setuid or setgid binaries. Add 'no-new-privileges:true' in 'security_opt' to prevent this.
- **Rule ID:** yaml.docker-compose.security.no-new-privileges.no-new-privileges
- **Severity:** HIGH
- **File:** docker-compose-postgres.yml
- **Lines Affected:** 3 - 3

This change is necessary to protect the application from potential security risks associated with this vulnerability.

**Solution Implemented:**

The automated remediation process has applied the necessary changes to the affected code in `docker-compose-postgres.yml` to resolve the identified issue.

Please review the changes to ensure they are correct and integrate as expected.