### PR TITLE
fix: Use exact match for scraping first

### DIFF
--- a/backend/app/models/item.py
+++ b/backend/app/models/item.py
@@ -192,10 +192,12 @@ class Item(Model, DbModelAuthorizeMixin):
     @classmethod
     def find_name_starts_with(cls, household_id: int, starts_with: str) -> Self | None:
         starts_with = starts_with.strip()
-        return cls.query.filter(
+        return (cls.query.filter(
             cls.household_id == household_id,
             func.lower(cls.name).like(func.lower(starts_with) + "%"),
-        ).first()
+        )
+        .order_by(cls.name)
+        .first())
 
     @classmethod
     def search_name(cls, name: str, household_id: int) -> list[Self]:

--- a/backend/app/service/recipe_scraping.py
+++ b/backend/app/service/recipe_scraping.py
@@ -96,9 +96,7 @@ def scrapePublic(url: str, html: str, household: Household) -> dict[str, Any] | 
     items = {}
     for ingredient in parseIngredients(scraper.ingredients(), household.language):
         name = ingredient.name if ingredient.name else ingredient.originalText or ""
-        item = Item.find_by_name(household.id, name)
-        if not item:
-            item = Item.find_name_starts_with(household.id, name)
+        item = Item.find_name_starts_with(household.id, name)
         if item:
             items[ingredient.originalText] = item.obj_to_dict() | {
                 "description": ingredient.description,

--- a/backend/app/service/recipe_scraping.py
+++ b/backend/app/service/recipe_scraping.py
@@ -96,7 +96,9 @@ def scrapePublic(url: str, html: str, household: Household) -> dict[str, Any] | 
     items = {}
     for ingredient in parseIngredients(scraper.ingredients(), household.language):
         name = ingredient.name if ingredient.name else ingredient.originalText or ""
-        item = Item.find_name_starts_with(household.id, name)
+        item = Item.find_by_name(household.id, name)
+        if not item:
+            item = Item.find_name_starts_with(household.id, name)
         if item:
             items[ingredient.originalText] = item.obj_to_dict() | {
                 "description": ingredient.description,


### PR DESCRIPTION
fix: try a exact match of scraped ingredients before using partial string match and order results of partial match to make it predictable

resolves #891 