### PR TITLE
POC: allow running kitchenowl-web as non-root user with arbitrary UID/GID

### DIFF
--- a/kitchenowl/Dockerfile
+++ b/kitchenowl/Dockerfile
@@ -54,8 +54,10 @@ RUN flutter build web --release --no-web-resources-cdn
 # ------------
 # RUNNER
 # ------------
-FROM nginx:stable-alpine
+FROM nginxinc/nginx-unprivileged:stable-alpine
 
+USER root
+RUN chmod -R 777 /etc/nginx/conf.d
 RUN apk add --no-cache bash
 RUN mkdir -p /var/www/web/kitchenowl
 COPY --from=builder /usr/local/src/app/build/web /var/www/web/kitchenowl
@@ -68,4 +70,4 @@ HEALTHCHECK --interval=30s --timeout=3s CMD curl -f http://localhost/ || exit 1
 ENV BACK_URL='back:5000'
 
 # Expose the web server
-EXPOSE 80
+EXPOSE 8080

--- a/kitchenowl/default.conf.template
+++ b/kitchenowl/default.conf.template
@@ -1,6 +1,6 @@
 server {
-    listen 80 default_server;
-    listen [::]:80 default_server;
+    listen 8080 default_server;
+    listen [::]:8080 default_server;
 
     root /var/www/web/kitchenowl;
     index index.html


### PR DESCRIPTION
This is a proof-of-concept for allowing the kitchenowl-web container to be run with any UID/GID. #684 discusses having the image run as non-root by default, but has been backlogged because it's a breaking change and is unclear how it'd be handled. In my opinion changing the default feels unnecessary as long as the container can be optionally run as-is with an arbitrary UID/GID via `--user`.

To give a concrete use case: I am self-hosting in a Kubernetes cluster alongside other unrelated applications. My applications all store data in the same persistent volume, but each app has its own sub-directory. As a guardrail, I run every application as a different, arbitrary, non-root UID/GID and then set permissions of the sub-directories accordingly. Then, in the event of container escape or a mistake on my end that would accidentally expose more of my volume than intended, only data for the compromised application will be accessible.

A couple common solutions that don't work for my thread model are:

- **Run container as root for initial setup, then container de-escalates itself to a standard user before launching the web application**: I don't trust this because it means I'm counting on the image to handle de-escalating, and it's totally possible that behavior would change at some point for some application after an update without me noticing, leaving my cluster vulnerable. Also, I have my cluster security set up where I can't easily run as a container as root (by design).
- **Container can be run with some _specific_ non-root UID (e.g. `101` for `nginx`)**: this prevents me from keeping separate permissions for separate applications. e.g. if I have multiple applications that need to run as UID 101 for nginx to function, then those applications could theoretically read each other's data.

#50 purportedly added some sort of support for running nginx in user-mode (I assume via the `nginx` user). From testing it seems the change does not encompass the use of arbitrary UID/GID. 

As-is, this solved for my use-case and is what I have deployed on my cluster, but there's a couple changes that'd need to be made to generalize this before it'd be ready to merge. @TomBursch Let me know if you're interested in the overall approach and I'm happy to make those changes. Didn't want to put in the extra work until I know you actually want this.