### PR TITLE
fix: "sign in" typo in oidc documentation

### DIFF
--- a/docs/docs/self-hosting/oidc.md
+++ b/docs/docs/self-hosting/oidc.md
@@ -65,7 +65,7 @@ which will result in an alternative mobile redirect URI for mobiles:
 Currently only Web, Android, iOS, and macOS are supported.
 
 ### Apple & Google
-These two providers will allow anyone to sing in with an Apple or Google account. They can be configured similarly to custom providers but will show up with a branded sign in with button.
+These two providers will allow anyone to sign in with an Apple or Google account. They can be configured similarly to custom providers but will show up with a branded sign in with button.
 It is not recommended setting up social logins for self-hosted versions as they might not work correctly.
 ```yaml
 back:


### PR DESCRIPTION
Hi, thank you for this project. 

I was reading through the docs and just so happened to notice this typo. Here is a fix for it.