### PR TITLE
Mention the importance of websockets

### DIFF
--- a/docs/docs/self-hosting/index.md
+++ b/docs/docs/self-hosting/index.md
@@ -71,6 +71,8 @@ The official installation method is using [Docker](https://docs.docker.com/engin
     - [https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Strict-Transport-Security](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Strict-Transport-Security)
     - [https://www.netsparker.com/blog/web-security/http-security-headers/](https://www.netsparker.com/blog/web-security/http-security-headers/)
 
+    Make sure the reverse proxy supports websockets. Without websockets some api requests might be noticeably slower.
+
 ### Updating KitchenOwl
 To upgrade a docker compose stack, you can simply run:
 


### PR DESCRIPTION
This PR contains a small addendum to the documentation. It mentions the importance of websockets for api calls such as the input of a new grocery items.
- When websockets are disabled by the reverse-proxy, calls to the backend are slow as observed in #682.
- When they are enabled, calls to the same endpoint feel much more responsive and don't have any noticeable delay

A new example for the traefik ingress controller has been added, containing a tested configuration.