### PR TITLE
Docs(docker-compose.yml): remove obsolete `version` property and updated `/advanced/` URL

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,4 +1,3 @@
-version: "3"
 services:
   front:
     image: tombursch/kitchenowl-web:latest
@@ -14,7 +13,7 @@ services:
     restart: unless-stopped
     environment:
       - JWT_SECRET_KEY=PLEASE_CHANGE_ME
-      # - FRONT_URL=http://localhost # Optional take a look at https://docs.kitchenowl.org/self-hosting/advanced/ for more info
+      # - FRONT_URL=http://localhost # Optional take a look at https://docs.kitchenowl.org/latest/self-hosting/advanced/ for more info
     volumes:
       - kitchenowl_data:/data
 


### PR DESCRIPTION
Removed the deprecated `version` field from `compose.yml` to prevent errors in Docker logs. Updated the `/advanced/` documentation link, which previously returned a 404, to the correct working URL in the latest KitchenOwl documentation (v0.7.4).