### PR TITLE
Feat/mass import shopping items

### DIFF
--- a/kitchenowl/lib/l10n/app_de.arb
+++ b/kitchenowl/lib/l10n/app_de.arb
@@ -252,6 +252,26 @@
   "@longPressToReorder": {},
   "@longerThanExpected": {},
   "@markAsPaid": {},
+  "@massImportButton": {},
+  "@massImportDescription": {},
+  "@massImportEnterText": {},
+  "@massImportError": {
+    "placeholders": {
+      "error": {
+        "type": "String"
+      }
+    }
+  },
+  "@massImportHint": {},
+  "@massImportNoValidItems": {},
+  "@massImportSuccess": {
+    "placeholders": {
+      "count": {
+        "type": "int"
+      }
+    }
+  },
+  "@massImportTitle": {},
   "@mealPlanner": {},
   "@member": {},
   "@memberAdd": {},
@@ -632,6 +652,14 @@
   "longPressToReorder": "Halte lang zum Umsortieren",
   "longerThanExpected": "Das dauert länger als erwartet",
   "markAsPaid": "Als gezahlt markieren",
+  "massImportButton": "Importiere Artikel",
+  "massImportDescription": "Gib Artikel einzeln pro Zeile ein.\nTrenne Name und Beschreibung mit '|', ';' oder ','",
+  "massImportEnterText": "Bitte gib etwas Text zum Importieren ein.",
+  "massImportError": "Fehler beim Importieren der Artikel: {error}",
+  "massImportHint": "Milch\nBrot | Für Sandwiches\nEier; 12er Packung",
+  "massImportNoValidItems": "Keine gültigen Artikel zum Importieren gefunden.",
+  "massImportSuccess": "Erfolgreich {count} Artikel importiert.",
+  "massImportTitle": "Massenimport",
   "mealPlanner": "Essensplaner",
   "member": "Mitglied",
   "memberAdd": "Mitglied hinzufügen",

--- a/kitchenowl/lib/l10n/app_en.arb
+++ b/kitchenowl/lib/l10n/app_en.arb
@@ -254,6 +254,26 @@
   "@longPressToReorder": {},
   "@longerThanExpected": {},
   "@markAsPaid": {},
+  "@massImportButton": {},
+  "@massImportDescription": {},
+  "@massImportEnterText": {},
+  "@massImportError": {
+    "placeholders": {
+      "error": {
+        "type": "String"
+      }
+    }
+  },
+  "@massImportHint": {},
+  "@massImportNoValidItems": {},
+  "@massImportSuccess": {
+    "placeholders": {
+      "count": {
+        "type": "int"
+      }
+    }
+  },
+  "@massImportTitle": {},
   "@mealPlanner": {},
   "@member": {},
   "@memberAdd": {},
@@ -645,6 +665,14 @@
   "longPressToReorder": "Long press to reorder",
   "longerThanExpected": "This is taking longer than expected",
   "markAsPaid": "Mark as paid",
+  "massImportButton": "Import Items",
+  "massImportDescription": "Enter items one per line.\nSeparate name and description with '|' or ';' or ','",
+  "massImportEnterText": "Please enter some text to import.",
+  "massImportError": "Error importing items: {error}",
+  "massImportHint": "Milk\nBread | For sandwiches\nEggs; 12 pack",
+  "massImportNoValidItems": "No valid items found to import.",
+  "massImportSuccess": "Successfully imported {count} items.",
+  "massImportTitle": "Mass Import",
   "mealPlanner": "Meal planner",
   "member": "Member",
   "memberAdd": "Add member",

--- a/kitchenowl/lib/pages/household_page/planner.dart
+++ b/kitchenowl/lib/pages/household_page/planner.dart
@@ -383,6 +383,23 @@ class _PlannerPageState extends State<PlannerPage> {
                         ),
                       ),
                     ),
+                  SliverPadding(
+                    padding: const EdgeInsets.all(16),
+                    sliver: SliverToBoxAdapter(
+                      child: ElevatedButton.icon(
+                        onPressed: () {
+                          // We pass the active cubit as an 'extra' object so the
+                          // new page can interact with the existing list.
+                          context.push(
+                            "/household/${cubit.household.id}/recipes/import",
+                            extra: household,
+                          );
+                        },
+                        icon: const Icon(Icons.input_rounded),
+                        label: const Text("Mass import"),
+                      ),
+                    ),
+                  ),
                 ],
               );
             },

--- a/kitchenowl/lib/pages/mass_import_page.dart
+++ b/kitchenowl/lib/pages/mass_import_page.dart
@@ -1,0 +1,226 @@
+import 'package:collection/collection.dart';
+import 'package:flutter/material.dart';
+import 'package:kitchenowl/models/household.dart';
+import 'package:kitchenowl/models/shoppinglist.dart';
+import 'package:kitchenowl/models/item.dart';
+import 'package:kitchenowl/services/transaction_handler.dart';
+import 'package:kitchenowl/services/transactions/shoppinglist.dart';
+// Import the new transaction file
+import 'package:kitchenowl/services/transactions/mass_import.dart';
+import 'package:kitchenowl/kitchenowl.dart';
+
+class MassImportPage extends StatefulWidget {
+  final Household household;
+
+  const MassImportPage({
+    super.key,
+    required this.household,
+  });
+
+  @override
+  State<MassImportPage> createState() => _MassImportPageState();
+}
+
+class _MassImportPageState extends State<MassImportPage> {
+  final TextEditingController _controller = TextEditingController();
+  bool _isLoading = false;
+
+  @override
+  void dispose() {
+    _controller.dispose();
+    super.dispose();
+  }
+
+  Future<void> _processImport(BuildContext context) async {
+    final text = _controller.text;
+
+    if (text.trim().isEmpty) {
+      ScaffoldMessenger.of(context).showSnackBar(
+        SnackBar(
+            content: Text(AppLocalizations.of(context)?.massImportEnterText ??
+                "Please enter some text to import.")),
+      );
+      return;
+    }
+
+    // 1. Parse all items
+    List<ShoppinglistItem> itemsToImport = [];
+    final lines = text.split('\n');
+
+    for (var line in lines) {
+      if (line.trim().isEmpty) continue;
+
+      final parts = line.split(RegExp(r'[|;,]'));
+      String name = parts[0].trim();
+      String description = '';
+
+      if (parts.length > 1) {
+        description = parts.sublist(1).join(" ").trim();
+      }
+
+      if (name.isNotEmpty) {
+        itemsToImport.add(ShoppinglistItem(
+          name: name,
+          description: description,
+          createdAt: DateTime.now(),
+        ));
+      }
+    }
+
+    if (itemsToImport.isEmpty) {
+      ScaffoldMessenger.of(context).showSnackBar(
+        SnackBar(content: Text(AppLocalizations.of(context)?.massImportNoValidItems ?? "No valid items found to import.")),
+      );
+      return;
+    }
+
+    setState(() {
+      _isLoading = true;
+    });
+
+    try {
+      final transactionHandler = TransactionHandler.getInstance();
+
+      // Resolve items using the search functionality
+      List<ShoppinglistItem> resolvedItems = [];
+      for (var item in itemsToImport) {
+        try {
+          final results = await transactionHandler.runTransaction(
+            TransactionShoppingListSearchItem(
+              household: widget.household,
+              query: item.name,
+            ),
+          );
+
+          final match = results.firstWhereOrNull(
+                  (e) => e.name.toLowerCase() == item.name.toLowerCase());
+
+          if (match != null) {
+            resolvedItems.add(ShoppinglistItem.fromItem(
+              item: match,
+              description: item.description,
+            ));
+          } else {
+            resolvedItems.add(item);
+          }
+        } catch (e) {
+          // If search fails, just add the item as is
+          resolvedItems.add(item);
+        }
+      }
+
+      // 2. Fetch available shopping lists for this household
+      final shoppingLists = await transactionHandler.runTransaction(
+        TransactionShoppingListGet(household: widget.household),
+        forceOffline: true, // Usually fine to use cached lists for selection
+      );
+
+      ShoppingList? targetList = widget.household.defaultShoppingList;
+
+      if (shoppingLists.length > 1) {
+        if (!mounted) return;
+
+        targetList = await showDialog<ShoppingList>(
+          context: context,
+          builder: (context) => SelectDialog(
+            title: AppLocalizations.of(context)!
+                .addNumberIngredients(resolvedItems.length),
+            cancelText: AppLocalizations.of(context)!.cancel,
+            options: shoppingLists
+                .map(
+                  (e) => SelectDialogOption(
+                e,
+                e.name,
+              ),
+            )
+                .toList(),
+          ),
+        );
+      } else if (shoppingLists.isNotEmpty) {
+        targetList = shoppingLists.first;
+      }
+
+      if (targetList != null) {
+        // 3. Perform the add transaction using the imported class
+        await transactionHandler.runTransaction(
+          TransactionShoppingListAddItems(
+            household: widget.household,
+            shoppinglist: targetList,
+            items: resolvedItems,
+          ),
+        );
+
+        if (mounted) {
+          ScaffoldMessenger.of(context).showSnackBar(
+            SnackBar(
+                content: Text(
+                    AppLocalizations.of(context)!.massImportSuccess(resolvedItems.length))),
+          );
+          _controller.clear();
+          Navigator.of(context).pop();
+        }
+      }
+    } catch (e) {
+      if (mounted) {
+        ScaffoldMessenger.of(context).showSnackBar(
+          SnackBar(content: Text(AppLocalizations.of(context)!.massImportError(e.toString()))),
+        );
+      }
+    } finally {
+      if (mounted) {
+        setState(() {
+          _isLoading = false;
+        });
+      }
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(
+        title: Text(AppLocalizations.of(context)?.massImportTitle ?? "Mass Import"),
+      ),
+      body: Padding(
+        padding: const EdgeInsets.all(16.0),
+        child: Column(
+          children: [
+            Text(
+              AppLocalizations.of(context)?.massImportDescription ?? "Enter items one per line.\nSeparate name and description with '|' or ';' or ','",
+              style: Theme.of(context).textTheme.bodyMedium,
+            ),
+            const SizedBox(height: 16),
+            Expanded(
+              child: TextField(
+                controller: _controller,
+                expands: true,
+                maxLines: null,
+                textAlignVertical: TextAlignVertical.top,
+                decoration: InputDecoration(
+                  border: const OutlineInputBorder(),
+                  hintText: AppLocalizations.of(context)?.massImportHint ?? "Milk\nBread | For sandwiches\nEggs; 12 pack",
+                  alignLabelWithHint: true,
+                ),
+              ),
+            ),
+            const SizedBox(height: 16),
+            SizedBox(
+              width: double.infinity,
+              child: ElevatedButton.icon(
+                onPressed: _isLoading ? null : () => _processImport(context),
+                icon: _isLoading
+                    ? const SizedBox(
+                  width: 20,
+                  height: 20,
+                  child: CircularProgressIndicator(strokeWidth: 2),
+                )
+                    : const Icon(Icons.playlist_add_rounded),
+                label: Text(AppLocalizations.of(context)?.massImportButton ?? "Import Items"),
+              ),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}

--- a/kitchenowl/lib/router.dart
+++ b/kitchenowl/lib/router.dart
@@ -18,6 +18,7 @@ import 'package:kitchenowl/pages/household_list_page.dart';
 import 'package:kitchenowl/pages/household_about_page.dart';
 import 'package:kitchenowl/pages/login_page.dart';
 import 'package:kitchenowl/pages/login_redirect_page.dart';
+import 'package:kitchenowl/pages/mass_import_page.dart';
 import 'package:kitchenowl/pages/onboarding_page.dart';
 import 'package:kitchenowl/pages/page_not_found.dart';
 import 'package:kitchenowl/pages/password_forgot_page.dart';
@@ -329,6 +330,18 @@ final router = GoRouter(
                         ),
                   ),
                 ),
+                GoRoute(
+                  parentNavigatorKey: _rootNavigatorKey,
+                  path: 'import',
+                  builder: (context, state) {
+                    final household = (state.extra is Household)
+                        ? state.extra as Household
+                        : Household(id: int.tryParse(state.pathParameters['id'] ?? '') ?? -1);
+
+                    return MassImportPage(household: household);
+                  },
+                ),
+
               ],
             ),
             GoRoute(

--- a/kitchenowl/lib/services/transactions/mass_import.dart
+++ b/kitchenowl/lib/services/transactions/mass_import.dart
@@ -1,0 +1,93 @@
+import 'package:kitchenowl/models/household.dart';
+import 'package:kitchenowl/models/item.dart';
+import 'package:kitchenowl/models/shoppinglist.dart';
+import 'package:kitchenowl/services/api/api_service.dart';
+import 'package:kitchenowl/services/storage/mem_storage.dart';
+import 'package:kitchenowl/services/transaction.dart';
+
+class TransactionShoppingListAddItems extends Transaction<bool> {
+  final Household household;
+  final ShoppingList shoppinglist;
+  final List<ShoppinglistItem> items;
+
+  TransactionShoppingListAddItems({
+    required this.household,
+    required this.shoppinglist,
+    required this.items,
+    DateTime? timestamp,
+  }) : super.internal(
+    timestamp ?? DateTime.now(),
+    "TransactionShoppingListAddItems",
+  );
+
+  factory TransactionShoppingListAddItems.fromJson(
+      Map<String, dynamic> map,
+      DateTime timestamp,
+      ) {
+    final List<ShoppinglistItem> items =
+    List.from(map['items'].map((e) => ShoppinglistItem.fromJson(e)));
+
+    return TransactionShoppingListAddItems(
+      household: Household.fromJson(map['household']),
+      shoppinglist: ShoppingList.fromJson(map['shoppinglist']),
+      items: items,
+      timestamp: timestamp,
+    );
+  }
+
+  @override
+  bool get saveTransaction => true;
+
+  @override
+  Map<String, dynamic> toJson() => super.toJson()
+    ..addAll({
+      "household": household.toJsonWithId(),
+      "shoppinglist": shoppinglist.toJsonWithId(),
+      "items": items.map((e) => e.toJsonWithId()).toList(),
+    });
+
+  @override
+  Future<bool> runLocal() async {
+    final shoppingLists =
+        await MemStorage.getInstance().readShoppingLists(household) ?? [];
+    final latestShoppingList =
+        shoppingLists.where((e) => e.id == shoppinglist.id).firstOrNull;
+    if (latestShoppingList == null) return false;
+
+    for (final item in items) {
+      final int i =
+      latestShoppingList.items.indexWhere((e) => e.name == item.name);
+
+      if (i >= 0) {
+        // If it exists, update it (e.g. append description if needed, or just keep existing)
+        // For mass import, usually we just append or overwrite.
+        // Here we just update the description if the new one has one.
+        if (item.description.isNotEmpty) {
+          latestShoppingList.items[i] = latestShoppingList.items[i].copyWith(
+            description: item.description,
+          );
+        }
+      } else {
+        latestShoppingList.items.add(item);
+        // Remove from recent items if it was there to avoid duplicates in suggestions
+        latestShoppingList.recentItems.removeWhere((e) => e.name == item.name);
+      }
+    }
+    MemStorage.getInstance().writeShoppingLists(household, shoppingLists);
+
+    return true;
+  }
+
+  @override
+  Future<bool?> runOnline() async {
+    // We iterate because the API might not support batch adding generic items yet.
+    for (final item in items) {
+      await ApiService.getInstance().addItemByName(
+        shoppinglist,
+        item.name,
+        item.description,
+      );
+    }
+    return true;
+  }
+}


### PR DESCRIPTION
Implementing feature request "Quick import a lot of groceries at once #448"

Added new page mass_import_page.dart to copy paste entries into.
Implemented import algorithm to deserialize entries, enrich them and add them to the shopping list.
Added new transaction mass_import.dart to add ShoppingItems to the shoppinglist.
Added corresponding translations to use in ui.
Added new button on meal planner (because feature request originated from meal prepping) and corresponding route.

Preview of new button:
<img width="216" height="420" alt="image" src="https://github.com/user-attachments/assets/a893ee88-2516-43df-b8f5-5314b8646f86" />

Preview of new page:
<img width="216" height="420" alt="image" src="https://github.com/user-attachments/assets/286fecff-1541-4fe2-97eb-aaecc5623ef5" />

I am a new contributor. i hope i am minding all contribution guidelines, best practises etc.
Eager to learn so please point out tips, misstakes i made etc.

