### PR TITLE
Add OCI source label

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -78,6 +78,8 @@ RUN python -c "import nltk; nltk.download('averaged_perceptron_tagger_eng', down
 # ------------
 FROM python:3.14-slim AS runner
 
+LABEL org.opencontainers.image.source="https://github.com/TomBursch/kitchenowl"
+
 RUN apt-get update \
     && apt-get install --yes --no-install-recommends \
         libxml2 libpcre2-dev libre2-dev libexpat1 curl \

--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -25,6 +25,8 @@ RUN python -c "import nltk; nltk.download('averaged_perceptron_tagger_eng', down
 # ------------
 FROM python:3.14-slim AS runner
 
+LABEL org.opencontainers.image.source="https://github.com/TomBursch/kitchenowl"
+
 RUN apt-get update \
     && apt-get install --yes --no-install-recommends \
         libxml2 libpcre2-dev libre2-dev libexpat1 curl \

--- a/kitchenowl/Dockerfile
+++ b/kitchenowl/Dockerfile
@@ -56,6 +56,8 @@ RUN flutter build web --release --no-web-resources-cdn
 # ------------
 FROM nginx:stable-alpine
 
+LABEL org.opencontainers.image.source="https://github.com/TomBursch/kitchenowl"
+
 RUN apk add --no-cache bash
 RUN mkdir -p /var/www/web/kitchenowl
 COPY --from=builder /usr/local/src/app/build/web /var/www/web/kitchenowl


### PR DESCRIPTION
This allows tools like Renovate to find where the source of these images is, and automatically fetch the changelog on a new release.

[Renovate documentation](https://docs.renovatebot.com/modules/datasource/docker/)