### PR TITLE
fix: explicitly set user agent for recipe scrape http requests

### DIFF
--- a/backend/app/service/recipe_scraping.py
+++ b/backend/app/service/recipe_scraping.py
@@ -2,6 +2,7 @@ import re
 from typing import Any
 from recipe_scrapers import scrape_html
 from recipe_scrapers._exceptions import SchemaOrgException
+import recipe_scrapers.__version__
 import requests
 from app.config import FRONT_URL
 from app.errors import ForbiddenRequest
@@ -9,6 +10,11 @@ from app.models.recipe import RecipeVisibility
 from app.service.ingredient_parsing import parseIngredients
 
 from app.models import Recipe, Item, Household
+
+# taken from the recipe-scrapers library to circumvent anti-scraping measures that block requests with the default user agent
+HEADERS = {
+    "User-Agent": f"Mozilla/5.0 (compatible; Windows NT 10.0; Win64; x64; rv:{recipe_scrapers.__version__}) recipe-scrapers/{recipe_scrapers.__version__}",
+}
 
 
 def scrapePublic(url: str, html: str, household: Household) -> dict[str, Any] | None:
@@ -181,7 +187,7 @@ def scrape(url: str, household: Household) -> dict[str, Any] | None:
         url = "http://" + url
 
     try:
-        res = requests.get(url=url)
+        res = requests.get(url=url, headers=HEADERS)
     except Exception:
         return None
     if res.status_code != requests.codes.ok:


### PR DESCRIPTION
This mirrors the upstream implementation of the `recipe-scrapers` built in `scrape_me` functionality where explicitly setting the user agent http header appears to circumvent some recipe pages "bot" protection measures.

It appears that the `recipe-scrapers` project tests their scrapers using their `scrape_me` functionality which sets this header which is why some sites supported by `recipe-scrapers` currently don't work within kitchenowl, e.g. www.seriouseats.com.

The upstream definition of the header can be found here:

https://github.com/hhursev/recipe-scrapers/blob/0e29ea87782c2c41f8e8e62d985343f2e3c67a6c/recipe_scrapers/_abstract.py#L17