### PR TITLE
fix: Improve Android sync reliability

### DIFF
--- a/kitchenowl/lib/app.dart
+++ b/kitchenowl/lib/app.dart
@@ -56,12 +56,13 @@ class App extends StatefulWidget {
   State<App> createState() => _AppState();
 }
 
-class _AppState extends State<App> {
+class _AppState extends State<App> with WidgetsBindingObserver {
   StreamSubscription? _intentDataStreamSubscription;
 
   @override
   void initState() {
     super.initState();
+    WidgetsBinding.instance.addObserver(this);
 
     if (!kIsWeb && (Platform.isAndroid || Platform.isIOS)) {
       final handler = ShareHandlerPlatform.instance;
@@ -112,7 +113,18 @@ class _AppState extends State<App> {
   }
 
   @override
+  void didChangeAppLifecycleState(AppLifecycleState state) {
+    super.didChangeAppLifecycleState(state);
+    if (state == AppLifecycleState.resumed) {
+      ApiService.getInstance().refresh().then((_) {
+        TransactionHandler.getInstance().runOpenTransactions();
+      });
+    }
+  }
+
+  @override
   void dispose() {
+    WidgetsBinding.instance.removeObserver(this);
     _intentDataStreamSubscription?.cancel();
     super.dispose();
   }


### PR DESCRIPTION
## Summary

Fixes unreliable shopping list sync on Android (and iOS) when the app is backgrounded or WebSocket connections are dropped.

**Root cause:** When the app returns from background, there was no lifecycle observer to trigger a data refresh. The WebSocket `onReconnect`/`onDisconnect` handlers only refresh API auth state (`ApiService.refresh()`), but don't notify cubits to re-fetch their data. Additionally, proxies (e.g. Cloudflare tunnels) that drop idle WebSocket connections cause silent data loss since missed events are never recovered.

**Changes:**

- **`app.dart`**: Add `WidgetsBindingObserver` to `_AppState` so that when the app resumes from background, it calls `ApiService.refresh()` followed by `TransactionHandler.runOpenTransactions()` to re-establish the connection and replay any pending offline changes.

- **`shoppinglist_cubit.dart`**: Add a connection state listener that triggers `refresh()` when the API transitions to `authenticated` (e.g. after reconnect), ensuring data is re-fetched whenever connectivity is restored. Also add a 30-second periodic refresh timer as a fallback for missed WebSocket events — only fires when authenticated to avoid wasted battery.

Both the listener and timer are properly cleaned up in `close()`.

## Test plan

- [ ] Install on two Android devices connected to the same KitchenOwl instance
- [ ] On Device A: add/remove shopping list items while Device B is backgrounded
- [ ] Bring Device B to foreground — verify items sync within 2-3 seconds
- [ ] Repeat in reverse direction
- [ ] Verify periodic refresh catches changes when WebSocket is unreliable (e.g. behind a proxy that drops idle connections)
- [ ] Verify no duplicate refreshes or excessive network calls during normal foreground use