### PR TITLE
feat: Add keep-screen-on setting for shopping list

### DIFF
--- a/kitchenowl/lib/cubits/settings_cubit.dart
+++ b/kitchenowl/lib/cubits/settings_cubit.dart
@@ -31,6 +31,8 @@ class SettingsCubit extends Cubit<SettingsState> {
         PreferenceStorage.getInstance().readBool(key: 'recentItemsCategorize');
     final restoreLastShoppingList = PreferenceStorage.getInstance()
         .readBool(key: 'restoreLastShoppingList');
+    final shoppingListKeepAwake = PreferenceStorage.getInstance()
+        .readBool(key: 'shoppingListKeepAwake');
 
     Config.deviceInfo = DeviceInfoPlugin().deviceInfo;
     Config.packageInfo = PackageInfo.fromPlatform();
@@ -56,6 +58,7 @@ class SettingsCubit extends Cubit<SettingsState> {
       shoppingListTapToRemove: await shoppingListTapToRemove ?? true,
       recentItemsCategorize: await recentItemsCategorize ?? false,
       restoreLastShoppingList: await restoreLastShoppingList ?? false,
+      shoppingListKeepAwake: await shoppingListKeepAwake ?? false,
     ));
   }
 
@@ -131,6 +134,14 @@ class SettingsCubit extends Cubit<SettingsState> {
     );
     emit(state.copyWith(restoreLastShoppingList: restoreLastShoppingList));
   }
+
+  void setShoppingListKeepAwake(bool shoppingListKeepAwake) {
+    PreferenceStorage.getInstance().writeBool(
+      key: 'shoppingListKeepAwake',
+      value: shoppingListKeepAwake,
+    );
+    emit(state.copyWith(shoppingListKeepAwake: shoppingListKeepAwake));
+  }
 }
 
 class SettingsState extends Equatable {
@@ -144,6 +155,7 @@ class SettingsState extends Equatable {
   final bool shoppingListTapToRemove;
   final bool recentItemsCategorize;
   final bool restoreLastShoppingList;
+  final bool shoppingListKeepAwake;
 
   const SettingsState({
     this.themeMode = ThemeMode.system,
@@ -156,6 +168,7 @@ class SettingsState extends Equatable {
     this.shoppingListTapToRemove = true,
     this.recentItemsCategorize = false,
     this.restoreLastShoppingList = false,
+    this.shoppingListKeepAwake = false,
   });
 
   SettingsState copyWith({
@@ -169,6 +182,7 @@ class SettingsState extends Equatable {
     bool? shoppingListTapToRemove,
     bool? recentItemsCategorize,
     bool? restoreLastShoppingList,
+    bool? shoppingListKeepAwake,
   }) =>
       SettingsState(
         themeMode: themeMode ?? this.themeMode,
@@ -184,6 +198,8 @@ class SettingsState extends Equatable {
             recentItemsCategorize ?? this.recentItemsCategorize,
         restoreLastShoppingList:
             restoreLastShoppingList ?? this.restoreLastShoppingList,
+        shoppingListKeepAwake:
+            shoppingListKeepAwake ?? this.shoppingListKeepAwake,
       );
 
   @override
@@ -198,5 +214,6 @@ class SettingsState extends Equatable {
         shoppingListTapToRemove,
         recentItemsCategorize,
         restoreLastShoppingList,
+        shoppingListKeepAwake,
       ];
 }

--- a/kitchenowl/lib/l10n/app_en.arb
+++ b/kitchenowl/lib/l10n/app_en.arb
@@ -335,6 +335,7 @@
   "@publicRecipeDescription": {},
   "@reason": {},
   "@recentItemsCategorize": {},
+  "@shoppingListKeepAwake": {},
   "@recipeAdd": {},
   "@recipeAddToHousehold": {
     "placeholders": {
@@ -746,6 +747,7 @@
   "shoppingListDeleteConfirmation": "Are you sure you want to delete {shoppingList}?",
   "shoppingListEdit": "Edit shopping list",
   "shoppingListEmpty": "The shopping list is empty. Add an item using the search function above.",
+  "shoppingListKeepAwake": "Keep screen on while shopping",
   "shoppingListStyle": "Shopping list style",
   "shoppingLists": "Shopping lists",
   "signInWith": "Sign in with {provider}",

--- a/kitchenowl/lib/pages/household_page/shoppinglist.dart
+++ b/kitchenowl/lib/pages/household_page/shoppinglist.dart
@@ -11,6 +11,7 @@ import 'package:kitchenowl/kitchenowl.dart';
 import 'package:kitchenowl/widgets/choice_scroll.dart';
 import 'package:kitchenowl/widgets/shopping_list/shopping_list_choice_chip.dart';
 import 'package:kitchenowl/widgets/shopping_list/sliver_shopinglist_item_view.dart';
+import 'package:wakelock_plus/wakelock_plus.dart';
 
 class ShoppinglistPage extends StatefulWidget {
   const ShoppinglistPage({super.key});
@@ -26,10 +27,14 @@ class _ShoppinglistPageState extends State<ShoppinglistPage> {
   void initState() {
     super.initState();
     searchController.text = BlocProvider.of<ShoppinglistCubit>(context).query;
+    if (BlocProvider.of<SettingsCubit>(context).state.shoppingListKeepAwake) {
+      WakelockPlus.enable();
+    }
   }
 
   @override
   void dispose() {
+    WakelockPlus.disable();
     searchController.dispose();
     super.dispose();
   }

--- a/kitchenowl/lib/pages/settings_page.dart
+++ b/kitchenowl/lib/pages/settings_page.dart
@@ -388,6 +388,25 @@ class _SettingsPageState extends State<SettingsPage> {
                   if (!kIsWeb)
                     ListTile(
                       title: Text(
+                        AppLocalizations.of(context)!.shoppingListKeepAwake,
+                      ),
+                      leading: const Icon(Icons.visibility_rounded),
+                      onTap: () => BlocProvider.of<SettingsCubit>(context)
+                          .setShoppingListKeepAwake(
+                        !BlocProvider.of<SettingsCubit>(context)
+                            .state
+                            .shoppingListKeepAwake,
+                      ),
+                      trailing: KitchenOwlSwitch(
+                        value: state.shoppingListKeepAwake,
+                        onChanged: (value) =>
+                            BlocProvider.of<SettingsCubit>(context)
+                                .setShoppingListKeepAwake(value),
+                      ),
+                    ),
+                  if (!kIsWeb)
+                    ListTile(
+                      title: Text(
                         AppLocalizations.of(context)!.forceOfflineMode,
                       ),
                       leading: const Icon(Icons.mobiledata_off_outlined),


### PR DESCRIPTION
## Summary

Adds a toggleable setting (off by default) that keeps the device screen awake while viewing the shopping list. This is useful when walking around a store checking off items — the screen won't lock mid-shop.

Uses the existing `wakelock_plus` dependency already used by the recipe cooking page, following the same enable-on-init / disable-on-dispose pattern.

**Changes:**

- **`settings_cubit.dart`**: Add `shoppingListKeepAwake` boolean setting, persisted via `PreferenceStorage`, defaults to `false`
- **`app_en.arb`**: Add localization string "Keep screen on while shopping"
- **`shoppinglist.dart`**: Enable wakelock in `initState` when the setting is on, disable in `dispose`
- **`settings_page.dart`**: Add toggle switch in settings (hidden on web where wakelock doesn't apply)

## Test plan

- [ ] Enable the setting in Settings, navigate to shopping list — verify screen stays on
- [ ] Disable the setting, navigate to shopping list — verify normal screen timeout behavior
- [ ] Setting persists across app restarts
- [ ] Toggle is not shown on web platform
- [ ] Navigating away from the shopping list (e.g. to recipes) disables the wakelock