### PR TITLE
feat: recipe title font size reduced and max line extended to 6

### DIFF
--- a/kitchenowl/lib/widgets/flexible_image_space_bar.dart
+++ b/kitchenowl/lib/widgets/flexible_image_space_bar.dart
@@ -23,6 +23,7 @@ class FlexibleImageSpaceBar extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     return FlexibleSpaceBar(
+      expandedTitleScale: 1.2,
       titlePadding: EdgeInsetsDirectional.only(
         start: 60,
         bottom: 16,
@@ -30,7 +31,7 @@ class FlexibleImageSpaceBar extends StatelessWidget {
       ),
       title: Text(
         title,
-        maxLines: isCollapsed ? 1 : 2,
+        maxLines: isCollapsed ? 1 : 6,
         overflow: TextOverflow.ellipsis,
         style: TextStyle(
           color: Theme.of(context).colorScheme.onSurface,

--- a/kitchenowl/lib/widgets/recipe_card.dart
+++ b/kitchenowl/lib/widgets/recipe_card.dart
@@ -184,9 +184,9 @@ class RecipeCard extends StatelessWidget {
                         recipe.name,
                         maxLines: getValueForScreenType(
                           context: context,
-                          mobile: 2,
-                          tablet: 2,
-                          desktop: 2,
+                          mobile: 4,
+                          tablet: 4,
+                          desktop: 4,
                         ),
                         overflow: TextOverflow.ellipsis,
                         softWrap: true,


### PR DESCRIPTION
Implementation for: https://github.com/TomBursch/kitchenowl/issues/934

## Summary

Improves the display of long recipe titles within the app. Previously, long names were truncated too early in both the recipe list and the detail view (after 2 lines), making it difficult to see the full name without entering edit mode.

## Changes
widgets/recipe_card.dart: Increased maxLines from 2 to 4, allowing longer titles to fit better below the image in the list view and reducing truncation.
widgets/flexible_image_space_bar.dart:
Increased maxLines in the expanded state (detail view) from 2 to 6.
Reduced expandedTitleScale from 1.5 (default) to 1.2, so the title appears more compact and obscures less of the recipe image.

## Test plan
- [ ] Create a recipe with a very long name (> 10 words).
- [ ] Check the Recipe List (Tab): The title should now take up to 4 lines before being truncated with "...", instead of just 2.
- [ ] Go to the Recipe Detail View: Upon pulling down (Expanded State), the title should display up to 6 lines and not completely cover the image (thanks to adjusted scaling).
- [ ] Scroll down (Collapsed State): The title should cleanly switch back to a single line in the App Bar.

## After the Change:
<img width="486" height="438" alt="image" src="https://github.com/user-attachments/assets/b03db5d4-6274-4256-94c3-9fb7e3593784" />

## Before the Change:
<img width="486" height="438" alt="image" src="https://github.com/user-attachments/assets/5333c9d3-1658-49cf-bb01-657369d577b4" />

