### PR TITLE
feat: move item to another list logic added

### DIFF
--- a/kitchenowl/lib/cubits/item_edit_cubit.dart
+++ b/kitchenowl/lib/cubits/item_edit_cubit.dart
@@ -90,6 +90,37 @@ class ItemEditCubit<T extends Item> extends Cubit<ItemEditState> {
     }
   }
 
+  Future<void> moveItem(ShoppingList targetList) async {
+    if (shoppingList == null || household == null) return;
+    if (shoppingList!.id == targetList.id) return;
+
+    await TransactionHandler.getInstance().runTransaction(
+      TransactionShoppingListAddItem(
+        household: household!,
+        shoppinglist: targetList,
+        item: item,
+      ),
+    );
+
+    if (_item is ShoppinglistItem) {
+      await TransactionHandler.getInstance().runTransaction(
+        TransactionShoppingListRemoveItem(
+          household: household!,
+          shoppinglist: shoppingList!,
+          item: _item as ShoppinglistItem,
+        ),
+      );
+    } else {
+      await TransactionHandler.getInstance().runTransaction(
+        TransactionShoppingListRemoveItem(
+          household: household!,
+          shoppinglist: targetList,
+          item: ShoppinglistItem.fromItem(item: item),
+        ),
+      );
+    }
+  }
+
   Future<bool> deleteItem() async {
     if (_item.id != null) {
       return ApiService.getInstance().deleteItem(_item);

--- a/kitchenowl/lib/pages/item_page.dart
+++ b/kitchenowl/lib/pages/item_page.dart
@@ -5,6 +5,7 @@ import 'package:intl/intl.dart';
 import 'package:kitchenowl/app.dart';
 import 'package:kitchenowl/cubits/household_cubit.dart';
 import 'package:kitchenowl/cubits/item_edit_cubit.dart';
+import 'package:kitchenowl/cubits/shoppinglist_cubit.dart';
 import 'package:kitchenowl/enums/update_enum.dart';
 import 'package:kitchenowl/helpers/build_context_extension.dart';
 import 'package:kitchenowl/helpers/item_description_parser.dart';
@@ -220,6 +221,56 @@ class _ItemPageState<T extends Item> extends State<ItemPage<T>> {
                                 ),
                               ],
                             ),
+                            if (widget.shoppingList != null &&
+                                widget.item is! RecipeItem) ...[
+                              const SizedBox(height: 16),
+                              Text(
+                                AppLocalizations.of(context)!.list,
+                                style: Theme.of(context).textTheme.bodySmall,
+                              ),
+                              Row(
+                                children: [
+                                  Expanded(
+                                    child: BlocBuilder<ShoppinglistCubit,
+                                        ShoppinglistCubitState>(
+                                      builder: (context, state) =>
+                                          DropdownButton<ShoppingList>(
+                                        value: state.shoppinglists.values
+                                            .firstWhereOrNull((e) =>
+                                                e.id ==
+                                                widget.shoppingList!.id),
+                                        isExpanded: true,
+                                        items: [
+                                          for (final list
+                                              in state.shoppinglists.values)
+                                            DropdownMenuItem(
+                                              value: list,
+                                              child: Text(list.name),
+                                            ),
+                                        ],
+                                        onChanged: !App.isOffline
+                                            ? (newList) async {
+                                                if (newList != null &&
+                                                    newList.id !=
+                                                        widget.shoppingList!
+                                                            .id &&
+                                                    newList.id != null) {
+                                                  await cubit.moveItem(newList);
+                                                  if (mounted) {
+                                                    Navigator.of(context).pop(
+                                                        const UpdateValue<Item>(
+                                                            UpdateEnum
+                                                                .deleted));
+                                                  }
+                                                }
+                                              }
+                                            : null,
+                                      ),
+                                    ),
+                                  ),
+                                ],
+                              ),
+                            ],
                             if (widget.item is ShoppinglistItem)
                               ListTile(
                                 contentPadding: EdgeInsets.zero,

--- a/kitchenowl/lib/widgets/sliver_item_grid_list.dart
+++ b/kitchenowl/lib/widgets/sliver_item_grid_list.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:kitchenowl/cubits/household_cubit.dart';
+import 'package:kitchenowl/cubits/shoppinglist_cubit.dart';
 import 'package:kitchenowl/enums/update_enum.dart';
 import 'package:kitchenowl/helpers/build_context_extension.dart';
 import 'package:kitchenowl/kitchenowl.dart';
@@ -101,6 +102,13 @@ class SliverItemGridList<T extends Item> extends StatelessWidget {
         if (householdCubit != null)
           page = BlocProvider.value(
             value: householdCubit,
+            child: page,
+          );
+
+        final shoppinglistCubit = context.readOrNull<ShoppinglistCubit>();
+        if (shoppinglistCubit != null)
+          page = BlocProvider.value(
+            value: shoppinglistCubit,
             child: page,
           );
 


### PR DESCRIPTION
Implementation for: https://github.com/TomBursch/kitchenowl/issues/985

## Summary
Adds the ability to move a shopping list item to a different list directly from the item details view, keeping the UI in sync and handling offline state.

## Changes
- kitchenowl/lib/cubits/item_edit_cubit.dart: Added moveItem to add the item to the target list and remove it from the source list in one flow.
- kitchenowl/lib/pages/item_page.dart: Added a shopping list dropdown for non-recipe items and wired it to moveItem.
- kitchenowl/lib/widgets/silver_item_grid_list.dart: Passed ShoppinglistCubit to ItemPage to populate the dropdown.

## Test plan
- [ ] Open an item from a shopping list and move it to another list via the dropdown.
- [ ] Verify the item is removed from the original list and added to the target list.
- [ ] Confirm the item detail view closes after moving and the list updates.

## Screenshots

<img width="486" height="438" alt="image" src="https://github.com/user-attachments/assets/d85bfe6e-71d2-445b-ab94-dea0b03f1d11" />

<img width="486" height="466" alt="image" src="https://github.com/user-attachments/assets/a186b0e6-3961-492c-bf00-f255fb529612" />

<img width="972" height="876" alt="image" src="https://github.com/user-attachments/assets/dc7315e1-f996-43ef-b5d0-a83054e73f3c" />


