### PR TITLE
feat: Add the ability to launch oidc flow by passing a query parameter.

### DIFF
--- a/docs/docs/self-hosting/oidc.md
+++ b/docs/docs/self-hosting/oidc.md
@@ -64,6 +64,9 @@ which will result in an alternative mobile redirect URI for mobiles:
 ### Limitations
 Currently only Web, Android, iOS, and macOS are supported.
 
+### Automatic Login
+It is possible to directly launch the OIDC flow from a link with a query parameter of `launch`. The correct URL would therefor be `FRONT_URL(1)/signin?launch=custom` to start the flow with your own OIDC provider.
+
 ### Apple & Google
 These two providers will allow anyone to sign in with an Apple or Google account. They can be configured similarly to custom providers but will show up with a branded sign in with button.
 It is not recommended setting up social logins for self-hosted versions as they might not work correctly.

--- a/kitchenowl/lib/pages/login_page.dart
+++ b/kitchenowl/lib/pages/login_page.dart
@@ -14,9 +14,11 @@ import 'package:kitchenowl/kitchenowl.dart';
 import 'package:kitchenowl/styles/color_mapper.dart';
 import 'package:responsive_builder/responsive_builder.dart';
 import 'package:sliver_tools/sliver_tools.dart';
+import 'package:kitchenowl/pages/splash_page.dart';
 
 class LoginPage extends StatefulWidget {
-  const LoginPage({super.key});
+  final String? launch;
+  const LoginPage({super.key, this.launch});
 
   @override
   State<LoginPage> createState() => _LoginPageState();
@@ -28,6 +30,14 @@ class _LoginPageState extends State<LoginPage> {
 
   @override
   Widget build(BuildContext context) {
+    if (widget.launch != null) {
+      var provider = OIDCProivder.parse(widget.launch as String);
+      if (provider != null && _providerEnabled(provider)) {
+        provider.login(context);
+        return const SplashPage();
+      }
+    }
+  
     return Scaffold(
       body: Row(
         crossAxisAlignment: CrossAxisAlignment.stretch,

--- a/kitchenowl/lib/router.dart
+++ b/kitchenowl/lib/router.dart
@@ -121,7 +121,9 @@ final router = GoRouter(
       pageBuilder: (context, state) => SharedAxisTransitionPage(
         key: state.pageKey,
         name: state.name,
-        child: const LoginPage(),
+        child: LoginPage(
+          launch: state.uri.queryParameters["launch"],
+        ),
       ),
       redirect: (BuildContext context, GoRouterState state) {
         final authState = BlocProvider.of<AuthCubit>(context).state;


### PR DESCRIPTION
Adds the ability to directly start the OIDC flow by passing a launch parameter to the URL. It reuses most of the already existing OIDC functionality.

It wasn't implemented as an unconditional redirect as otherwise the mobile apps wouldn't be able to switch the server anymore. Together with #1037 it should make for a much nicer OIDC experience.

Fixes #800 and #924 