### PR TITLE
fix: prevent iOS session loss caused by background fetch token rotation

### DIFF
--- a/kitchenowl/lib/services/api/api_service.dart
+++ b/kitchenowl/lib/services/api/api_service.dart
@@ -57,7 +57,7 @@ class ApiService {
   Map<String, String> headers = {};
   Future<void>? _refreshThread;
 
-  static void Function(String)? _handleTokenRotation;
+  static Future<void> Function(String)? _handleTokenRotation;
   static Future<String?> Function(String?)? _handleTokenBeforeReauth;
 
   static final ValueNotifier<Connection> _connectionNotifier =
@@ -145,7 +145,7 @@ class ApiService {
     _serverInfoNotifier.removeListener(f);
   }
 
-  static void setTokenRotationHandler(void Function(String) handler) {
+  static void setTokenRotationHandler(Future<void> Function(String) handler) {
     _handleTokenRotation = handler;
   }
 
@@ -353,7 +353,7 @@ class ApiService {
         headers['Authorization'] = 'Bearer ${body['access_token']}';
         _refreshToken = body['refresh_token'];
         if (_handleTokenRotation != null) {
-          _handleTokenRotation!(_refreshToken!);
+          await _handleTokenRotation!(_refreshToken!);
         }
 
         return true;

--- a/kitchenowl/lib/services/storage/storage.dart
+++ b/kitchenowl/lib/services/storage/storage.dart
@@ -8,7 +8,11 @@ abstract class Storage {
 }
 
 class SecureStorage extends Storage {
-  final _storage = const FlutterSecureStorage();
+  final _storage = const FlutterSecureStorage(
+    iOptions: IOSOptions(
+      accessibility: KeychainAccessibility.first_unlock,
+    ),
+  );
   static SecureStorage? _instance;
 
   SecureStorage._internal();


### PR DESCRIPTION
Background fetch runs roughly every 30 minutes. When API calls during background fetch encounter an expired access token (15-minute lifetime), the refresh endpoint rotates the refresh token. However, the new token fails to persist to the iOS Keychain because the default accessibility level (`kSecAttrAccessibleWhenUnlocked`) blocks writes when the device is locked.

When iOS later terminates the app, the in-memory token is lost and the stale token remains in the Keychain. On the next launch, the server receives the old token, being reused after the new one was already active - which is rightfully detected as a token theft attack, so the whole session ends up invalidated.

**Important note**: I don't have a Mac, so unfortunately this isn't tested. I looked into it because #1023 was getting a bit annoying, and the reasoning seems correct, but without a local build, I unfortunately can't confirm. `dart analyze` is at least happy with those changes.