### PR TITLE
Increase client_max_body_size to 32M

### DIFF
--- a/kitchenowl/default.conf.template
+++ b/kitchenowl/default.conf.template
@@ -14,6 +14,7 @@ server {
     location /api/ {
         include uwsgi_params;
         uwsgi_pass ${BACK_URL};
+        client_max_body_size 32M;
     }
     location /mcp {
         include uwsgi_params;


### PR DESCRIPTION
Fix error 413 when uploading images.

May belong to point 6 from #179
