### PR TITLE
add pPadding to MarkdownBuilder

### DIFF
--- a/kitchenowl/lib/widgets/kitchenowl_markdown_builder.dart
+++ b/kitchenowl/lib/widgets/kitchenowl_markdown_builder.dart
@@ -184,6 +184,7 @@ class _KitchenOwlMarkdownBuilderState extends State<KitchenOwlMarkdownBuilder>
               borderRadius: BorderRadius.circular(2.0),
             ),
             textScaler: widget.textScaler,
+            pPadding: const EdgeInsets.only(bottom: 12),
           ),
       imageDirectory: widget.imageDirectory,
       imageBuilder: widget.imageBuilder ??


### PR DESCRIPTION
resolves #1027 by adding `pPadding` (for p-elements) to MarkdownBuilder. Feels a bit hacky but seems to help.

<img width="642" height="422" alt="image" src="https://github.com/user-attachments/assets/8b097bd5-5f7f-4391-a53e-6c85650a7fe6" />
