### PR TITLE
feat: recipe performance improvements for large collections

### DIFF
--- a/backend/.gitignore
+++ b/backend/.gitignore
@@ -1,5 +1,7 @@
 *.db
 *.db-journal
+*.db-shm
+*.db-wal
 upload/
 
 # Visual Studio Code related

--- a/backend/app/config.py
+++ b/backend/app/config.py
@@ -24,6 +24,7 @@ from oic.oic.message import RegistrationResponse
 from oic.utils.authn.client import CLIENT_AUTHN_METHOD
 from flask import Flask, jsonify, request
 from flask_basicauth import BasicAuth
+from flask_compress import Compress
 from flask_migrate import Migrate
 from flask_sqlalchemy import SQLAlchemy
 from flask_bcrypt import Bcrypt
@@ -180,6 +181,10 @@ convention = {
     "pk": "pk_%(table_name)s",
 }
 
+
+app.config["COMPRESS_MIMETYPES"] = ["application/json"]
+app.config["COMPRESS_MIN_SIZE"] = 500
+Compress(app)
 
 db = SQLAlchemy(app, model_class=DbModelBase)
 migrate = Migrate(app, db, render_as_batch=True)

--- a/backend/app/config.py
+++ b/backend/app/config.py
@@ -308,7 +308,7 @@ if DB_URL.drivername == "sqlite":
 
     def on_sqlite_connect(conn, unused):
         conn.enable_load_extension(True)
-        conn.load_extension(cast(str, sqlite_icu.extension_path()).replace(".so", ""))
+        conn.load_extension(cast(str, sqlite_icu.extension_path()))
         conn.enable_load_extension(False)
 
         cursor = conn.cursor()

--- a/backend/app/controller/recipe/recipe_controller.py
+++ b/backend/app/controller/recipe/recipe_controller.py
@@ -278,7 +278,9 @@ def deleteRecipeById(id):
     recipe.checkAuthorized()
     household_id = recipe.household_id
     recipe_id = recipe.id
-    recipe.delete()
+    # Use session.delete directly (not recipe.delete()) so the tombstone lands
+    # in the same transaction and a crash between the two can't lose a deletion.
+    db.session.delete(recipe)
     tombstone = RecipeTombstone()
     tombstone.recipe_id = recipe_id
     tombstone.household_id = household_id
@@ -292,9 +294,9 @@ def deleteRecipeById(id):
 @authorize_household()
 @validate_args(SearchByNameRequest)
 def searchRecipeInHouseholdByName(args, household_id):
-    if "only_ids" in args and args["only_ids"]:
+    if args["only_ids"]:
         return jsonify([e.id for e in Recipe.search_name(args["query"], household_id)])
-    use_slim = request.args.get("details") == "slim"
+    use_slim = args["details"] == "slim"
     serializer = Recipe.obj_to_slim_dict if use_slim else Recipe.obj_to_full_dict
     query_opts = [noload(Recipe.items)] if use_slim else []
     return jsonify(
@@ -307,7 +309,7 @@ def searchRecipeInHouseholdByName(args, household_id):
 @authorize_household()
 @validate_args(GetAllFilterRequest)
 def getAllFiltered(args, household_id):
-    use_slim = request.args.get("details") == "slim"
+    use_slim = args["details"] == "slim"
     serializer = Recipe.obj_to_slim_dict if use_slim else Recipe.obj_to_full_dict
     query_opts = [noload(Recipe.items)] if use_slim else []
     return jsonify(

--- a/backend/app/controller/recipe/recipe_controller.py
+++ b/backend/app/controller/recipe/recipe_controller.py
@@ -1,5 +1,7 @@
 import re
+from datetime import datetime, timezone
 from sqlalchemy import desc, func
+from sqlalchemy.orm import noload
 from app.config import FRONT_URL
 from app.errors import NotFoundRequest
 from app.models import Household, RecipeItems, RecipeTags
@@ -7,7 +9,7 @@ from flask import jsonify, Blueprint
 from flask_jwt_extended import current_user, jwt_required
 from app import db
 from app.helpers import validate_args, authorize_household
-from app.models import Recipe, Item, Tag
+from app.models import Recipe, Item, Tag, RecipeTombstone
 from app.models.recipe import RecipeVisibility
 from app.service.file_has_access_or_download import file_has_access_or_download
 from app.service.recipe_scraping import scrape
@@ -19,6 +21,8 @@ from .schemas import (
     GetAllFilterRequest,
     ScrapeRecipe,
     SuggestionsRecipe,
+    GetAllRecipesRequest,
+    SyncRecipesRequest,
 )
 
 recipe = Blueprint("recipe", __name__)
@@ -28,10 +32,75 @@ recipeHousehold = Blueprint("recipe", __name__)
 @recipeHousehold.route("", methods=["GET"])
 @jwt_required()
 @authorize_household()
-def getAllRecipes(household_id):
-    return jsonify(
-        [e.obj_to_full_dict() for e in Recipe.all_from_household_by_name(household_id)]
+@validate_args(GetAllRecipesRequest)
+def getAllRecipes(args, household_id):
+    use_slim = args["details"] == "slim"
+    per_page: int = args["per_page"]
+    page: int = args["page"]
+    query_opts = [noload(Recipe.items)] if use_slim else []
+    serializer = Recipe.obj_to_slim_dict if use_slim else Recipe.obj_to_full_dict
+    if per_page > 0:
+        base_query = (
+            Recipe.query
+            .filter(Recipe.household_id == household_id)
+            .options(*query_opts)
+            .order_by(Recipe.name)
+        )
+        total = base_query.count()
+        items = base_query.offset(page * per_page).limit(per_page).all()
+        return jsonify({
+            "items": [serializer(e) for e in items],
+            "total": total,
+            "page": page,
+            "per_page": per_page,
+        })
+    recipes = (
+        Recipe.query
+        .filter(Recipe.household_id == household_id)
+        .options(*query_opts)
+        .order_by(Recipe.name)
+        .all()
     )
+    return jsonify([serializer(e) for e in recipes])
+
+
+@recipeHousehold.route("/sync", methods=["GET"])
+@jwt_required()
+@authorize_household()
+@validate_args(SyncRecipesRequest)
+def syncRecipes(args, household_id):
+    updated_after_ts: float = args["updated_after"]
+    page: int = args["page"]
+    per_page: int = args["per_page"]
+
+    server_now = datetime.now(timezone.utc)
+    since = (
+        datetime.fromtimestamp(updated_after_ts, tz=timezone.utc)
+        if updated_after_ts > 0
+        else None
+    )
+
+    query = Recipe.query.filter(Recipe.household_id == household_id)
+    if since is not None:
+        query = query.filter(Recipe.updated_at > since)
+    query = query.order_by(Recipe.updated_at, Recipe.id)
+
+    total = query.count()
+    recipes = query.offset(page * per_page).limit(per_page).all()
+    has_more = (page + 1) * per_page < total
+
+    epoch = datetime.fromtimestamp(0, tz=timezone.utc)
+    deleted_ids = RecipeTombstone.deleted_since(
+        household_id, since if since is not None else epoch
+    )
+
+    return jsonify({
+        "recipes": [e.obj_to_full_dict() for e in recipes],
+        "deleted_ids": deleted_ids,
+        "page": page,
+        "has_more": has_more,
+        "server_time": server_now.timestamp(),
+    })
 
 
 @recipeHousehold.route("/newest/<int:page>", methods=["GET"])
@@ -207,7 +276,14 @@ def deleteRecipeById(id):
     if not recipe:
         raise NotFoundRequest()
     recipe.checkAuthorized()
+    household_id = recipe.household_id
+    recipe_id = recipe.id
     recipe.delete()
+    tombstone = RecipeTombstone()
+    tombstone.recipe_id = recipe_id
+    tombstone.household_id = household_id
+    db.session.add(tombstone)
+    db.session.commit()
     return jsonify({"msg": "DONE"})
 
 
@@ -218,8 +294,11 @@ def deleteRecipeById(id):
 def searchRecipeInHouseholdByName(args, household_id):
     if "only_ids" in args and args["only_ids"]:
         return jsonify([e.id for e in Recipe.search_name(args["query"], household_id)])
+    use_slim = request.args.get("details") == "slim"
+    serializer = Recipe.obj_to_slim_dict if use_slim else Recipe.obj_to_full_dict
+    query_opts = [noload(Recipe.items)] if use_slim else []
     return jsonify(
-        [e.obj_to_full_dict() for e in Recipe.search_name(args["query"], household_id)]
+        [serializer(e) for e in Recipe.search_name(args["query"], household_id, query_options=query_opts)]
     )
 
 
@@ -228,10 +307,13 @@ def searchRecipeInHouseholdByName(args, household_id):
 @authorize_household()
 @validate_args(GetAllFilterRequest)
 def getAllFiltered(args, household_id):
+    use_slim = request.args.get("details") == "slim"
+    serializer = Recipe.obj_to_slim_dict if use_slim else Recipe.obj_to_full_dict
+    query_opts = [noload(Recipe.items)] if use_slim else []
     return jsonify(
         [
-            e.obj_to_full_dict()
-            for e in Recipe.all_by_name_with_filter(household_id, args["filter"])
+            serializer(e)
+            for e in Recipe.all_by_name_with_filter(household_id, args["filter"], query_options=query_opts)
         ]
     )
 

--- a/backend/app/controller/recipe/schemas.py
+++ b/backend/app/controller/recipe/schemas.py
@@ -48,12 +48,14 @@ class UpdateRecipe(Schema):
 
 
 class SearchByNameRequest(Schema):
+    class Meta:
+        unknown = EXCLUDE
+
     query = fields.String(required=True, validate=lambda a: a and not a.isspace())
     page = fields.Integer(validate=lambda a: a >= 0, load_default=0)
     language = fields.String()
-    only_ids = fields.Boolean(
-        load_default=False,
-    )
+    only_ids = fields.Boolean(load_default=False)
+    details = fields.String(load_default="full")
 
 
 class SearchByTagRequest(Schema):
@@ -63,7 +65,11 @@ class SearchByTagRequest(Schema):
 
 
 class GetAllFilterRequest(Schema):
+    class Meta:
+        unknown = EXCLUDE
+
     filter = fields.List(fields.String())
+    details = fields.String(load_default="full")
 
 
 class AddItemByName(Schema):

--- a/backend/app/controller/recipe/schemas.py
+++ b/backend/app/controller/recipe/schemas.py
@@ -83,3 +83,21 @@ class ScrapeRecipe(Schema):
 
 class SuggestionsRecipe(Schema):
     language = fields.String()
+
+
+class GetAllRecipesRequest(Schema):
+    class Meta:
+        unknown = EXCLUDE
+
+    details = fields.String(load_default="full")
+    page = fields.Integer(validate=lambda a: a >= 0, load_default=0)
+    per_page = fields.Integer(validate=lambda a: a >= 0, load_default=0)
+
+
+class SyncRecipesRequest(Schema):
+    class Meta:
+        unknown = EXCLUDE
+
+    updated_after = fields.Float(validate=lambda a: a >= 0, load_default=0.0)
+    page = fields.Integer(validate=lambda a: a >= 0, load_default=0)
+    per_page = fields.Integer(validate=lambda a: a >= 0, load_default=50)

--- a/backend/app/jobs/jobs.py
+++ b/backend/app/jobs/jobs.py
@@ -10,6 +10,7 @@ from app.models import (
     Recipe,
     ChallengePasswordReset,
     OIDCRequest,
+    RecipeTombstone,
 )
 from app.service.delete_unused import deleteEmptyHouseholds, deleteUnusedFiles
 from .item_ordering import findItemOrdering
@@ -76,6 +77,7 @@ if celery_app is not None:
 def monthly():
     deleteEmptyHouseholds()
     deleteUnusedFiles()
+    RecipeTombstone.prune()
 
 
 def daily():

--- a/backend/app/models/__init__.py
+++ b/backend/app/models/__init__.py
@@ -4,7 +4,7 @@ from .association import Association
 from .expense import Expense, ExpensePaidFor
 from .settings import Settings
 from .history import History, Status
-from .recipe import RecipeTags, RecipeItems, Recipe
+from .recipe import RecipeTags, RecipeItems, Recipe, RecipeTombstone
 from .planner import Planner
 from .tag import Tag
 from .shoppinglist import ShoppinglistItems, Shoppinglist

--- a/backend/app/models/recipe.py
+++ b/backend/app/models/recipe.py
@@ -435,8 +435,16 @@ class RecipeItems(Model):
         ).first()
 
 
+TOMBSTONE_RETENTION_DAYS = 90
+
+
 class RecipeTombstone(Model):
-    """Tracks deleted recipes so incremental sync clients can remove them."""
+    """Tracks deleted recipes so incremental sync clients can remove them.
+
+    Tombstones older than TOMBSTONE_RETENTION_DAYS are pruned by the monthly
+    job. Clients whose cursor predates the pruning horizon should perform a
+    full resync (fetch updated_after=0 to rebuild the local store).
+    """
     __tablename__ = "recipe_tombstone"
 
     id: Mapped[int] = db.Column(db.Integer, primary_key=True)
@@ -446,13 +454,6 @@ class RecipeTombstone(Model):
     )
 
     @classmethod
-    def record(cls, recipe_id: int, household_id: int) -> None:
-        tombstone = cls()
-        tombstone.recipe_id = recipe_id
-        tombstone.household_id = household_id
-        db.session.add(tombstone)
-
-    @classmethod
     def deleted_since(
         cls, household_id: int, since: "datetime"
     ) -> list[int]:
@@ -460,6 +461,13 @@ class RecipeTombstone(Model):
         if since.timestamp() > 0:
             query = query.filter(cls.created_at > since)
         return [t.recipe_id for t in query.all()]
+
+    @classmethod
+    def prune(cls) -> None:
+        from datetime import timezone as tz
+        horizon = datetime.now(tz.utc) - timedelta(days=TOMBSTONE_RETENTION_DAYS)
+        cls.query.filter(cls.created_at < horizon).delete()
+        db.session.commit()
 
 
 class RecipeTags(Model):

--- a/backend/app/models/recipe.py
+++ b/backend/app/models/recipe.py
@@ -156,6 +156,13 @@ class Recipe(Model, DbModelAuthorizeMixin):
                 del res[column_name]
         return res
 
+    def obj_to_slim_dict(self) -> dict[str, Any]:
+        """Metadata-only dict for list views: no items, no description, no household."""
+        res = self.obj_to_dict()
+        res.pop("description", None)
+        res["tags"] = [e.obj_to_item_dict() for e in self.tags]
+        return res
+
     def obj_to_full_dict(
         self,
         skip_columns: list[str] | None = None,
@@ -257,6 +264,15 @@ class Recipe(Model, DbModelAuthorizeMixin):
         )
 
     @classmethod
+    def all_from_household_by_name_paginated(
+        cls, household_id: int, page: int, per_page: int
+    ) -> tuple[list[Self], int]:
+        query = cls.query.filter(cls.household_id == household_id).order_by(cls.name)
+        total = query.count()
+        items = query.offset(page * per_page).limit(per_page).all()
+        return items, total
+
+    @classmethod
     def find_by_name(cls, household_id: int, name: str) -> Self | None:
         return cls.query.filter(
             cls.household_id == household_id, cls.name == name
@@ -269,13 +285,16 @@ class Recipe(Model, DbModelAuthorizeMixin):
         household_id: int | None = None,
         page: int = 0,
         language: str | None = None,
+        query_options: list | None = None,
     ) -> list[Self]:
         query = cls.query
+        if query_options:
+            query = query.options(*query_options)
 
         from app.models import Household
 
         if household_id is not None:
-            query.filter(
+            query = query.filter(
                 cls.household_id == household_id,
             )
         else:
@@ -340,7 +359,7 @@ class Recipe(Model, DbModelAuthorizeMixin):
 
     @classmethod
     def all_by_name_with_filter(
-        cls, household_id: int, filter: list[str]
+        cls, household_id: int, filter: list[str], query_options: list | None = None
     ) -> list[Self]:
         sq = (
             db.session.query(RecipeTags.recipe_id)
@@ -348,12 +367,14 @@ class Recipe(Model, DbModelAuthorizeMixin):
             .filter(Tag.name.in_(filter))
             .subquery()
         )
-        return (
+        query = (
             db.session.query(cls)
             .filter(cls.household_id == household_id, cls.id.in_(sq))
             .order_by(cls.name)
-            .all()
         )
+        if query_options:
+            query = query.options(*query_options)
+        return query.all()
 
 
 class RecipeItems(Model):
@@ -412,6 +433,33 @@ class RecipeItems(Model):
         return cls.query.filter(
             cls.recipe_id == recipe_id, cls.item_id == item_id
         ).first()
+
+
+class RecipeTombstone(Model):
+    """Tracks deleted recipes so incremental sync clients can remove them."""
+    __tablename__ = "recipe_tombstone"
+
+    id: Mapped[int] = db.Column(db.Integer, primary_key=True)
+    recipe_id: Mapped[int] = db.Column(db.Integer, nullable=False, index=True)
+    household_id: Mapped[int] = db.Column(
+        db.Integer, db.ForeignKey("household.id"), nullable=False, index=True
+    )
+
+    @classmethod
+    def record(cls, recipe_id: int, household_id: int) -> None:
+        tombstone = cls()
+        tombstone.recipe_id = recipe_id
+        tombstone.household_id = household_id
+        db.session.add(tombstone)
+
+    @classmethod
+    def deleted_since(
+        cls, household_id: int, since: "datetime"
+    ) -> list[int]:
+        query = cls.query.filter(cls.household_id == household_id)
+        if since.timestamp() > 0:
+            query = query.filter(cls.created_at > since)
+        return [t.recipe_id for t in query.all()]
 
 
 class RecipeTags(Model):

--- a/backend/migrations/versions/a1b2c3d4e5f6_.py
+++ b/backend/migrations/versions/a1b2c3d4e5f6_.py
@@ -1,0 +1,46 @@
+"""add recipe_tombstone table
+
+Revision ID: a1b2c3d4e5f6
+Revises: 0b10d67750be
+Create Date: 2026-07-11 00:00:00.000000
+
+"""
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision = 'a1b2c3d4e5f6'
+down_revision = '0b10d67750be'
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    op.create_table(
+        'recipe_tombstone',
+        sa.Column('id', sa.Integer(), nullable=False),
+        sa.Column('recipe_id', sa.Integer(), nullable=False),
+        sa.Column('household_id', sa.Integer(), nullable=False),
+        sa.Column('created_at', sa.DateTime(), nullable=False),
+        sa.Column('updated_at', sa.DateTime(), nullable=False),
+        sa.ForeignKeyConstraint(
+            ['household_id'], ['household.id'],
+            name=op.f('fk_recipe_tombstone_household_id_household'),
+        ),
+        sa.PrimaryKeyConstraint('id', name=op.f('pk_recipe_tombstone')),
+    )
+    with op.batch_alter_table('recipe_tombstone', schema=None) as batch_op:
+        batch_op.create_index(
+            op.f('ix_recipe_tombstone_household_id'), ['household_id'], unique=False
+        )
+        batch_op.create_index(
+            op.f('ix_recipe_tombstone_recipe_id'), ['recipe_id'], unique=False
+        )
+
+
+def downgrade():
+    with op.batch_alter_table('recipe_tombstone', schema=None) as batch_op:
+        batch_op.drop_index(op.f('ix_recipe_tombstone_recipe_id'))
+        batch_op.drop_index(op.f('ix_recipe_tombstone_household_id'))
+    op.drop_table('recipe_tombstone')

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -10,6 +10,7 @@ dependencies = [
     "apscheduler>=3.11.0",
     "blurhash-python>=1.2.2",
     "flask>=3.1.0",
+    "flask-compress>=1.15",
     "flask-apscheduler>=1.13.1",
     "flask-basicauth>=0.2.0",
     "flask-bcrypt>=1.0.1",

--- a/backend/tests/api/test_api_planner.py
+++ b/backend/tests/api/test_api_planner.py
@@ -25,7 +25,9 @@ def test_meal_planning_cooking_date_field(
     actual = datetime.fromtimestamp(
         planned_meals[0]["cooking_date"] / 1000, timezone.utc
     ).replace(tzinfo=None)
-    expected = datetime.fromtimestamp(pytest.FIX_DATETIME / 1000, None)
+    expected = datetime.fromtimestamp(
+        pytest.FIX_DATETIME / 1000, timezone.utc
+    ).replace(tzinfo=None)
     assert actual == expected
 
 

--- a/backend/tests/api/test_api_recipe.py
+++ b/backend/tests/api/test_api_recipe.py
@@ -97,3 +97,38 @@ def test_recipe_deletion(user_client_with_household, recipe_with_items):
     # Verify deletion
     response = user_client_with_household.get(f"/api/recipe/{recipe_id}")
     assert response.status_code != 200  # Should not be found
+
+
+# --- New endpoint tests ---
+
+
+def test_search_is_scoped_to_household(
+    admin_client,
+    user_client_with_household,
+    household_id,
+    recipe_with_items,
+    recipe_name,
+):
+    """Cross-household search leak regression: a recipe in household A must not
+    appear in a search on household B."""
+    # Create a second household via admin
+    response = admin_client.get("/api/user")
+    assert response.status_code == 200
+    admin_id = response.get_json()["id"]
+
+    response = admin_client.post(
+        "/api/household", json={"name": "other household", "member": [admin_id]}
+    )
+    assert response.status_code == 200
+    other_household_id = response.get_json()["id"]
+
+    # Search other household for the recipe name — must return nothing
+    response = admin_client.get(
+        f"/api/household/{other_household_id}/recipe/search?query={recipe_name}"
+    )
+    assert response.status_code == 200
+    results = response.get_json()
+    ids = [r["id"] for r in results]
+    assert recipe_with_items not in ids, (
+        "Recipe from another household leaked into search results"
+    )

--- a/backend/tests/api/test_api_recipe.py
+++ b/backend/tests/api/test_api_recipe.py
@@ -102,6 +102,125 @@ def test_recipe_deletion(user_client_with_household, recipe_with_items):
 # --- New endpoint tests ---
 
 
+def test_slim_list_omits_items_and_description(
+    user_client_with_household, household_id, recipe_with_items
+):
+    """?details=slim omits items and description; tags are present."""
+    response = user_client_with_household.get(
+        f"/api/household/{household_id}/recipe?details=slim"
+    )
+    assert response.status_code == 200
+    recipes = response.get_json()
+    assert len(recipes) > 0
+    for r in recipes:
+        assert "items" not in r, "slim response must not include items"
+        assert "description" not in r, "slim response must not include description"
+        assert "tags" in r
+
+
+def test_full_list_still_includes_items(
+    user_client_with_household, household_id, recipe_with_items
+):
+    """Default (no ?details) response still returns full dict with items."""
+    response = user_client_with_household.get(
+        f"/api/household/{household_id}/recipe"
+    )
+    assert response.status_code == 200
+    recipes = response.get_json()
+    recipe = next(r for r in recipes if r["id"] == recipe_with_items)
+    assert "items" in recipe
+    assert "description" in recipe
+
+
+def test_pagination_math(user_client_with_household, household_id, recipe_with_items):
+    """page/per_page returns wrapped response with total and correct slice."""
+    response = user_client_with_household.get(
+        f"/api/household/{household_id}/recipe?details=slim&page=0&per_page=1"
+    )
+    assert response.status_code == 200
+    body = response.get_json()
+    assert "items" in body
+    assert "total" in body
+    assert body["page"] == 0
+    assert body["per_page"] == 1
+    assert len(body["items"]) <= 1
+    assert body["total"] >= 1
+
+
+def test_pagination_bad_params_returns_400(user_client_with_household, household_id):
+    """Non-integer page param returns 400, not 500."""
+    response = user_client_with_household.get(
+        f"/api/household/{household_id}/recipe?page=notanint"
+    )
+    assert response.status_code == 400
+
+
+def test_sync_endpoint_returns_required_fields(
+    user_client_with_household, household_id, recipe_with_items
+):
+    """Sync endpoint returns recipes, deleted_ids, has_more, and server_time."""
+    response = user_client_with_household.get(
+        f"/api/household/{household_id}/recipe/sync?updated_after=0"
+    )
+    assert response.status_code == 200
+    body = response.get_json()
+    assert "recipes" in body
+    assert "deleted_ids" in body
+    assert "has_more" in body
+    assert "server_time" in body
+    assert isinstance(body["server_time"], float)
+    assert any(r["id"] == recipe_with_items for r in body["recipes"])
+    assert "items" in body["recipes"][0]  # full dict, not slim
+
+
+def test_sync_endpoint_delta_window(
+    user_client_with_household, household_id, recipe_with_items
+):
+    """updated_after=<future> returns no recipes (nothing updated yet)."""
+    import time
+    future = int(time.time()) + 86400  # 1 day ahead
+    response = user_client_with_household.get(
+        f"/api/household/{household_id}/recipe/sync?updated_after={future}"
+    )
+    assert response.status_code == 200
+    body = response.get_json()
+    assert body["recipes"] == []
+
+
+def test_tombstone_created_on_delete(
+    user_client_with_household, household_id, recipe_with_items
+):
+    """Deleting a recipe creates a tombstone visible in the sync deleted_ids."""
+    recipe_id = recipe_with_items
+    user_client_with_household.delete(f"/api/recipe/{recipe_id}")
+
+    response = user_client_with_household.get(
+        f"/api/household/{household_id}/recipe/sync?updated_after=0"
+    )
+    assert response.status_code == 200
+    body = response.get_json()
+    assert recipe_id in body["deleted_ids"]
+
+
+def test_filtered_slim_omits_items(
+    user_client_with_household, household_id, recipe_with_items
+):
+    """POST /filter with details=slim in body must not return items."""
+    tag_name = "dessert"
+    user_client_with_household.post(
+        f"/api/recipe/{recipe_with_items}", json={"tags": [tag_name]}
+    )
+    response = user_client_with_household.post(
+        f"/api/household/{household_id}/recipe/filter",
+        json={"filter": [tag_name], "details": "slim"},
+    )
+    assert response.status_code == 200
+    recipes = response.get_json()
+    assert len(recipes) > 0
+    for r in recipes:
+        assert "items" not in r, "filtered slim response must not include items"
+
+
 def test_search_is_scoped_to_household(
     admin_client,
     user_client_with_household,

--- a/backend/uv.lock
+++ b/backend/uv.lock
@@ -298,6 +298,45 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/77/a3/9a94cb58332bf0ca76176389f818f37521515ce82acd7d7fed5d15e27150/blurhash-python-1.2.2.tar.gz", hash = "sha256:f2dbb8a58c5a299c8fca81112e52471a15cff38020ca9a65dae96a777609b8d4", size = 178331, upload-time = "2024-01-24T12:09:08.004Z" }
 
 [[package]]
+name = "brotli"
+version = "1.2.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/f7/16/c92ca344d646e71a43b8bb353f0a6490d7f6e06210f8554c8f874e454285/brotli-1.2.0.tar.gz", hash = "sha256:e310f77e41941c13340a95976fe66a8a95b01e783d430eeaf7a2f87e0a57dd0a", size = 7388632, upload-time = "2025-11-05T18:39:42.86Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/17/e1/298c2ddf786bb7347a1cd71d63a347a79e5712a7c0cba9e3c3458ebd976f/brotli-1.2.0-cp314-cp314-macosx_10_15_universal2.whl", hash = "sha256:6c12dad5cd04530323e723787ff762bac749a7b256a5bece32b2243dd5c27b21", size = 863080, upload-time = "2025-11-05T18:38:45.503Z" },
+    { url = "https://files.pythonhosted.org/packages/84/0c/aac98e286ba66868b2b3b50338ffbd85a35c7122e9531a73a37a29763d38/brotli-1.2.0-cp314-cp314-macosx_10_15_x86_64.whl", hash = "sha256:3219bd9e69868e57183316ee19c84e03e8f8b5a1d1f2667e1aa8c2f91cb061ac", size = 445453, upload-time = "2025-11-05T18:38:46.433Z" },
+    { url = "https://files.pythonhosted.org/packages/ec/f1/0ca1f3f99ae300372635ab3fe2f7a79fa335fee3d874fa7f9e68575e0e62/brotli-1.2.0-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:963a08f3bebd8b75ac57661045402da15991468a621f014be54e50f53a58d19e", size = 1528168, upload-time = "2025-11-05T18:38:47.371Z" },
+    { url = "https://files.pythonhosted.org/packages/d6/a6/2ebfc8f766d46df8d3e65b880a2e220732395e6d7dc312c1e1244b0f074a/brotli-1.2.0-cp314-cp314-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:9322b9f8656782414b37e6af884146869d46ab85158201d82bab9abbcb971dc7", size = 1627098, upload-time = "2025-11-05T18:38:48.385Z" },
+    { url = "https://files.pythonhosted.org/packages/f3/2f/0976d5b097ff8a22163b10617f76b2557f15f0f39d6a0fe1f02b1a53e92b/brotli-1.2.0-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:cf9cba6f5b78a2071ec6fb1e7bd39acf35071d90a81231d67e92d637776a6a63", size = 1419861, upload-time = "2025-11-05T18:38:49.372Z" },
+    { url = "https://files.pythonhosted.org/packages/9c/97/d76df7176a2ce7616ff94c1fb72d307c9a30d2189fe877f3dd99af00ea5a/brotli-1.2.0-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:7547369c4392b47d30a3467fe8c3330b4f2e0f7730e45e3103d7d636678a808b", size = 1484594, upload-time = "2025-11-05T18:38:50.655Z" },
+    { url = "https://files.pythonhosted.org/packages/d3/93/14cf0b1216f43df5609f5b272050b0abd219e0b54ea80b47cef9867b45e7/brotli-1.2.0-cp314-cp314-musllinux_1_2_ppc64le.whl", hash = "sha256:fc1530af5c3c275b8524f2e24841cbe2599d74462455e9bae5109e9ff42e9361", size = 1593455, upload-time = "2025-11-05T18:38:51.624Z" },
+    { url = "https://files.pythonhosted.org/packages/b3/73/3183c9e41ca755713bdf2cc1d0810df742c09484e2e1ddd693bee53877c1/brotli-1.2.0-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:d2d085ded05278d1c7f65560aae97b3160aeb2ea2c0b3e26204856beccb60888", size = 1488164, upload-time = "2025-11-05T18:38:53.079Z" },
+    { url = "https://files.pythonhosted.org/packages/64/6a/0c78d8f3a582859236482fd9fa86a65a60328a00983006bcf6d83b7b2253/brotli-1.2.0-cp314-cp314-win32.whl", hash = "sha256:832c115a020e463c2f67664560449a7bea26b0c1fdd690352addad6d0a08714d", size = 339280, upload-time = "2025-11-05T18:38:54.02Z" },
+    { url = "https://files.pythonhosted.org/packages/f5/10/56978295c14794b2c12007b07f3e41ba26acda9257457d7085b0bb3bb90c/brotli-1.2.0-cp314-cp314-win_amd64.whl", hash = "sha256:e7c0af964e0b4e3412a0ebf341ea26ec767fa0b4cf81abb5e897c9338b5ad6a3", size = 375639, upload-time = "2025-11-05T18:38:55.67Z" },
+]
+
+[[package]]
+name = "brotlicffi"
+version = "1.2.0.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "cffi" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/8a/b6/017dc5f852ed9b8735af77774509271acbf1de02d238377667145fcee01d/brotlicffi-1.2.0.1.tar.gz", hash = "sha256:c20d5c596278307ad06414a6d95a892377ea274a5c6b790c2548c009385d621c", size = 478156, upload-time = "2026-03-05T19:54:11.547Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ef/f9/dfa56316837fa798eac19358351e974de8e1e2ca9475af4cb90293cd6576/brotlicffi-1.2.0.1-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:2c85e65913cf2b79c57a3fdd05b98d9731d9255dc0cb696b09376cc091b9cddd", size = 433046, upload-time = "2026-03-05T19:53:46.209Z" },
+    { url = "https://files.pythonhosted.org/packages/4a/f5/f8f492158c76b0d940388801f04f747028971ad5774287bded5f1e53f08d/brotlicffi-1.2.0.1-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:535f2d05d0273408abc13fc0eebb467afac17b0ad85090c8913690d40207dac5", size = 1541126, upload-time = "2026-03-05T19:53:48.248Z" },
+    { url = "https://files.pythonhosted.org/packages/3b/e1/ff87af10ac419600c63e9287a0649c673673ae6b4f2bcf48e96cb2f89f60/brotlicffi-1.2.0.1-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:ce17eb798ca59ecec67a9bb3fd7a4304e120d1cd02953ce522d959b9a84d58ac", size = 1541983, upload-time = "2026-03-05T19:53:50.317Z" },
+    { url = "https://files.pythonhosted.org/packages/47/c0/80ecd9bd45776109fab14040e478bf63e456967c9ddee2353d8330ed8de1/brotlicffi-1.2.0.1-cp314-cp314t-win32.whl", hash = "sha256:3c9544f83cb715d95d7eab3af4adbbef8b2093ad6382288a83b3a25feb1a57ec", size = 349047, upload-time = "2026-03-05T19:53:52.215Z" },
+    { url = "https://files.pythonhosted.org/packages/ab/98/13e5b250236a281b6cd9e92a01ee1ae231029fa78faee932ef3766e1cb24/brotlicffi-1.2.0.1-cp314-cp314t-win_amd64.whl", hash = "sha256:625f8115d32ae9c0740d01ea51518437c3fbaa3e78d41cb18459f6f7ac326000", size = 385652, upload-time = "2026-03-05T19:53:53.892Z" },
+    { url = "https://files.pythonhosted.org/packages/9a/9f/b98dcd4af47994cee97aebac866996a006a2e5fc1fd1e2b82a8ad95cf09c/brotlicffi-1.2.0.1-cp38-abi3-macosx_11_0_arm64.whl", hash = "sha256:91ba5f0ccc040f6ff8f7efaf839f797723d03ed46acb8ae9408f99ffd2572cf4", size = 432608, upload-time = "2026-03-05T19:53:56.736Z" },
+    { url = "https://files.pythonhosted.org/packages/b1/7a/ac4ee56595a061e3718a6d1ea7e921f4df156894acffb28ed88a1fd52022/brotlicffi-1.2.0.1-cp38-abi3-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:be9a670c6811af30a4bd42d7116dc5895d3b41beaa8ed8a89050447a0181f5ce", size = 1534257, upload-time = "2026-03-05T19:53:58.667Z" },
+    { url = "https://files.pythonhosted.org/packages/99/39/e7410db7f6f56de57744ea52a115084ceb2735f4d44973f349bb92136586/brotlicffi-1.2.0.1-cp38-abi3-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:6f3314a3476f59e5443f9f72a6dff16edc0c3463c9b318feaef04ae3e4683f5a", size = 1536838, upload-time = "2026-03-05T19:54:00.705Z" },
+    { url = "https://files.pythonhosted.org/packages/a6/75/6e7977d1935fc3fbb201cbd619be8f2c7aea25d40a096967132854b34708/brotlicffi-1.2.0.1-cp38-abi3-win32.whl", hash = "sha256:82ea52e2b5d3145b6c406ebd3efb0d55db718b7ad996bd70c62cec0439de1187", size = 343337, upload-time = "2026-03-05T19:54:02.446Z" },
+    { url = "https://files.pythonhosted.org/packages/d8/ef/e7e485ce5e4ba3843a0a92feb767c7b6098fd6e65ce752918074d175ae71/brotlicffi-1.2.0.1-cp38-abi3-win_amd64.whl", hash = "sha256:da2e82a08e7778b8bc539d27ca03cdd684113e81394bfaaad8d0dfc6a17ddede", size = 379026, upload-time = "2026-03-05T19:54:04.322Z" },
+]
+
+[[package]]
 name = "celery"
 version = "5.6.3"
 source = { registry = "https://pypi.org/simple" }
@@ -732,6 +771,20 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/0c/f4/25dccfafad391d305b63eb6031e7c1dbb757169d54d3a73292939201698e/Flask-Bcrypt-1.0.1.tar.gz", hash = "sha256:f07b66b811417ea64eb188ae6455b0b708a793d966e1a80ceec4a23bc42a4369", size = 5996, upload-time = "2022-04-05T03:59:52.682Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/8b/72/af9a3a3dbcf7463223c089984b8dd4f1547593819e24d57d9dc5873e04fe/Flask_Bcrypt-1.0.1-py3-none-any.whl", hash = "sha256:062fd991dc9118d05ac0583675507b9fe4670e44416c97e0e6819d03d01f808a", size = 6050, upload-time = "2022-04-05T03:59:51.589Z" },
+]
+
+[[package]]
+name = "flask-compress"
+version = "1.24"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "brotli", marker = "platform_python_implementation != 'PyPy'" },
+    { name = "brotlicffi", marker = "platform_python_implementation == 'PyPy'" },
+    { name = "flask" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/c2/de/2ae0118051b38ab53437328074a696f3ee7d61e15bf7454b78a3088e5bc3/flask_compress-1.24.tar.gz", hash = "sha256:14097cefe59ecb3e466d52a6aeb62f34f125a9f7dadf1f33a53e430ce4a50f31", size = 21089, upload-time = "2026-03-31T15:01:39.005Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/4c/0f/fe51e0b2301bbd429af44273a923ff92127b18d13abba5ae5a1d60e8e497/flask_compress-1.24-py3-none-any.whl", hash = "sha256:1e63668eb6e3242bd4f6ad98825a924e3984409be90c125477893d586007d00c", size = 11033, upload-time = "2026-03-31T15:01:37.302Z" },
 ]
 
 [[package]]
@@ -1262,6 +1315,7 @@ dependencies = [
     { name = "flask-apscheduler" },
     { name = "flask-basicauth" },
     { name = "flask-bcrypt" },
+    { name = "flask-compress" },
     { name = "flask-jwt-extended" },
     { name = "flask-migrate" },
     { name = "flask-socketio" },
@@ -1313,6 +1367,7 @@ requires-dist = [
     { name = "flask-apscheduler", specifier = ">=1.13.1" },
     { name = "flask-basicauth", specifier = ">=0.2.0" },
     { name = "flask-bcrypt", specifier = ">=1.0.1" },
+    { name = "flask-compress", specifier = ">=1.15" },
     { name = "flask-jwt-extended", specifier = ">=4.7.1" },
     { name = "flask-migrate", specifier = ">=4.1.0" },
     { name = "flask-socketio", specifier = ">=5.5.1" },

--- a/kitchenowl/lib/cubits/recipe_cubit.dart
+++ b/kitchenowl/lib/cubits/recipe_cubit.dart
@@ -73,10 +73,18 @@ class RecipeCubit extends Cubit<RecipeState> {
 
     Recipe? inHouseholdRecipe;
     if (state.household != null && recipe.householdId != state.household!.id) {
-      final allRecipes = await TransactionHandler.getInstance().runTransaction(
+      var allRecipes = await TransactionHandler.getInstance().runTransaction(
         TransactionRecipeGetRecipes(household: state.household!),
         forceOffline: true,
       );
+      // Cold-cache fallback: MemStorage is empty on first launch before the
+      // background sync has run. Fetch a slim page directly so the "already
+      // added" indicator works without waiting for a full sync.
+      if (allRecipes.isEmpty) {
+        final result =
+            await ApiService.getInstance().getRecipesPaginated(state.household!);
+        allRecipes = result?.items ?? [];
+      }
       inHouseholdRecipe = allRecipes.firstWhereOrNull((r) {
         if (r.source.trim().isEmpty) return false;
         final match = RegExp(

--- a/kitchenowl/lib/cubits/recipe_list_cubit.dart
+++ b/kitchenowl/lib/cubits/recipe_list_cubit.dart
@@ -1,9 +1,13 @@
 import 'package:equatable/equatable.dart';
+import 'package:flutter/foundation.dart' show kIsWeb;
 import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:kitchenowl/models/household.dart';
 import 'package:kitchenowl/models/recipe.dart';
 import 'package:kitchenowl/models/tag.dart';
+import 'package:kitchenowl/services/api/api_service.dart';
+import 'package:kitchenowl/services/recipe_sync_service.dart';
 import 'package:kitchenowl/services/storage/storage.dart';
+import 'package:kitchenowl/services/storage/mem_storage.dart';
 import 'package:kitchenowl/services/transaction_handler.dart';
 import 'package:kitchenowl/services/transactions/recipe.dart';
 import 'package:kitchenowl/services/transactions/tag.dart';
@@ -13,6 +17,8 @@ class RecipeListCubit extends Cubit<RecipeListState> {
   List<Recipe> recipeList = [];
   Future<void>? _refreshThread;
   String? _refreshCurrentQuery;
+
+  static const int _perPage = 50;
 
   RecipeListCubit(this.household) : super(const LoadingRecipeListState()) {
     PreferenceStorage.getInstance().readBool(key: 'recipeListView').then((i) {
@@ -79,7 +85,76 @@ class RecipeListCubit extends Cubit<RecipeListState> {
     return _refreshThread!;
   }
 
+  Future<void> loadMore() async {
+    final currentState = state;
+    if (currentState is! ListRecipeListState) return;
+    if (!currentState.hasMore) return;
+    if (currentState.isLoadingMore) return;
+    // search/filter states don't paginate
+    if (currentState is SearchRecipeListState) return;
+    if (currentState is FilteredListRecipeListState) return;
+
+    final nextPage = currentState.currentPage + 1;
+    emit(currentState.copyWith(isLoadingMore: true));
+
+    try {
+      final result = await ApiService.getInstance().getRecipesPaginated(
+        household,
+        page: nextPage,
+        perPage: _perPage,
+      );
+      if (result == null) {
+        if (!isClosed && state is ListRecipeListState) {
+          emit((state as ListRecipeListState).copyWith(isLoadingMore: false));
+        }
+        return;
+      }
+
+      final merged = List<Recipe>.from(recipeList)..addAll(result.items);
+      recipeList = merged;
+
+      final tags =
+          await TransactionHandler.getInstance().runTransaction(
+        TransactionTagGetAll(household: household),
+        forceOffline: true,
+      );
+
+      Set<Tag> filter = const {};
+      if (state is FilteredListRecipeListState) {
+        filter = (state as FilteredListRecipeListState).selectedTags;
+      }
+
+      if (!isClosed) {
+        emit(filter.isNotEmpty
+            ? FilteredListRecipeListState(
+                recipes: _getFilteredRecipesCopy(merged, filter),
+                tags: tags,
+                selectedTags: filter,
+                allRecipes: merged,
+                listView: state.listView,
+                hasMore: result.hasMore,
+                currentPage: nextPage,
+              )
+            : ListRecipeListState(
+                recipes: merged,
+                tags: tags,
+                listView: state.listView,
+                hasMore: result.hasMore,
+                currentPage: nextPage,
+              ));
+      }
+    } catch (_) {
+      // restore previous state without loading indicator
+      if (!isClosed && state is ListRecipeListState) {
+        emit((state as ListRecipeListState).copyWith(isLoadingMore: false));
+      }
+    }
+  }
+
   Future<void> _initialLoad() async {
+    // On web skip local cache — rely on network only
+    if (kIsWeb) return;
+
     final tags = TransactionHandler.getInstance().runTransaction(
       TransactionTagGetAll(household: household),
       forceOffline: true,
@@ -124,33 +199,93 @@ class RecipeListCubit extends Cubit<RecipeListState> {
       );
     } else {
       if (!runOffline && state is SearchRecipeListState) _refresh(query, true);
-      final tags = TransactionHandler.getInstance().runTransaction(
-        TransactionTagGetAll(household: household),
-        forceOffline: runOffline,
-      );
-      recipeList = await TransactionHandler.getInstance().runTransaction(
-        TransactionRecipeGetRecipes(household: household),
-        forceOffline: runOffline,
-      );
-      Set<Tag> filter = const {};
-      if (state is FilteredListRecipeListState && (query == null)) {
-        filter = (state as FilteredListRecipeListState).selectedTags;
+
+      try {
+        final tags = TransactionHandler.getInstance().runTransaction(
+          TransactionTagGetAll(household: household),
+          forceOffline: runOffline,
+        );
+
+        if (runOffline) {
+          recipeList = await TransactionHandler.getInstance().runTransaction(
+            TransactionRecipeGetRecipes(household: household),
+            forceOffline: true,
+          );
+          Set<Tag> filter = const {};
+          if (state is FilteredListRecipeListState && (query == null)) {
+            filter = (state as FilteredListRecipeListState).selectedTags;
+          }
+          _state = filter.isNotEmpty
+              ? FilteredListRecipeListState(
+                  recipes: _getFilteredRecipesCopy(recipeList, filter),
+                  tags: await tags,
+                  selectedTags: filter,
+                  allRecipes: recipeList,
+                  listView: state.listView,
+                )
+              : ListRecipeListState(
+                  recipes: recipeList,
+                  tags: await tags,
+                  listView: state.listView,
+                );
+        } else {
+          // Load first page from network
+          final result = await ApiService.getInstance().getRecipesPaginated(
+            household,
+            page: 0,
+            perPage: _perPage,
+          );
+          if (result == null) {
+            if (query == _refreshCurrentQuery && !isClosed) {
+              // Only show error page when there's nothing cached to display
+              if (recipeList.isEmpty) {
+                emit(ErrorRecipeListState(listView: state.listView));
+              }
+              _refreshThread = null;
+            }
+            return;
+          }
+          recipeList = result.items;
+          // Do NOT write slim list to the offline cache — the background sync
+          // service writes full-detail recipes. Only mobile uses offline cache.
+          if (!kIsWeb) {
+            RecipeSyncService.getInstance().sync(household);
+          }
+
+          Set<Tag> filter = const {};
+          if (state is FilteredListRecipeListState && (query == null)) {
+            filter = (state as FilteredListRecipeListState).selectedTags;
+          }
+          _state = filter.isNotEmpty
+              ? FilteredListRecipeListState(
+                  recipes: _getFilteredRecipesCopy(recipeList, filter),
+                  tags: await tags,
+                  selectedTags: filter,
+                  allRecipes: recipeList,
+                  listView: state.listView,
+                  hasMore: result.hasMore,
+                  currentPage: 0,
+                )
+              : ListRecipeListState(
+                  recipes: recipeList,
+                  tags: await tags,
+                  listView: state.listView,
+                  hasMore: result.hasMore,
+                  currentPage: 0,
+                );
+        }
+      } catch (_) {
+        if (query == _refreshCurrentQuery && !isClosed) {
+          // Only replace current list with error state when there's nothing to show
+          if (recipeList.isEmpty) {
+            emit(ErrorRecipeListState(listView: state.listView));
+          }
+          _refreshThread = null;
+        }
+        return;
       }
-      _state = filter.isNotEmpty
-          ? FilteredListRecipeListState(
-              recipes: _getFilteredRecipesCopy(recipeList, filter),
-              tags: await tags,
-              selectedTags: filter,
-              allRecipes: recipeList,
-              listView: state.listView,
-            )
-          : ListRecipeListState(
-              recipes: recipeList,
-              tags: await tags,
-              listView: state.listView,
-            );
     }
-    if (query == _refreshCurrentQuery) {
+    if (query == _refreshCurrentQuery && !isClosed) {
       emit(_state);
       _refreshThread = null;
     }
@@ -192,25 +327,51 @@ class LoadingRecipeListState extends RecipeListState {
   }
 }
 
+class ErrorRecipeListState extends RecipeListState {
+  const ErrorRecipeListState({super.listView});
+
+  @override
+  RecipeListState copyWith({bool? listView}) {
+    return ErrorRecipeListState(listView: listView ?? this.listView);
+  }
+}
+
 class ListRecipeListState extends RecipeListState {
   final List<Recipe> recipes;
   final Set<Tag> tags;
+  final bool hasMore;
+  final bool isLoadingMore;
+  final int currentPage;
 
   const ListRecipeListState({
     this.recipes = const [],
     this.tags = const {},
     super.listView,
+    this.hasMore = false,
+    this.isLoadingMore = false,
+    this.currentPage = 0,
   });
 
   @override
-  List<Object?> get props => super.props + <Object?>[tags] + recipes;
+  List<Object?> get props =>
+      super.props + <Object?>[tags, hasMore, isLoadingMore, currentPage] + recipes;
 
   @override
-  RecipeListState copyWith({bool? listView}) {
+  ListRecipeListState copyWith({
+    bool? listView,
+    List<Recipe>? recipes,
+    Set<Tag>? tags,
+    bool? hasMore,
+    bool? isLoadingMore,
+    int? currentPage,
+  }) {
     return ListRecipeListState(
       listView: listView ?? this.listView,
-      recipes: recipes,
-      tags: tags,
+      recipes: recipes ?? this.recipes,
+      tags: tags ?? this.tags,
+      hasMore: hasMore ?? this.hasMore,
+      isLoadingMore: isLoadingMore ?? this.isLoadingMore,
+      currentPage: currentPage ?? this.currentPage,
     );
   }
 }
@@ -225,6 +386,9 @@ class FilteredListRecipeListState extends ListRecipeListState {
     super.recipes = const [],
     super.tags = const {},
     super.listView,
+    super.hasMore = false,
+    super.isLoadingMore = false,
+    super.currentPage = 0,
   });
 
   factory FilteredListRecipeListState.fromState(
@@ -239,6 +403,8 @@ class FilteredListRecipeListState extends ListRecipeListState {
         tags: state.tags,
         selectedTags: {selectedTag},
         listView: state.listView,
+        hasMore: state.hasMore,
+        currentPage: state.currentPage,
       );
 
   @override
@@ -247,6 +413,9 @@ class FilteredListRecipeListState extends ListRecipeListState {
     List<Recipe>? recipes,
     Set<Tag>? tags,
     Set<Tag>? selectedTags,
+    bool? hasMore,
+    bool? isLoadingMore,
+    int? currentPage,
   }) =>
       FilteredListRecipeListState(
         listView: listView ?? this.listView,
@@ -254,6 +423,9 @@ class FilteredListRecipeListState extends ListRecipeListState {
         tags: tags ?? this.tags,
         selectedTags: selectedTags ?? this.selectedTags,
         allRecipes: allRecipes,
+        hasMore: hasMore ?? this.hasMore,
+        isLoadingMore: isLoadingMore ?? this.isLoadingMore,
+        currentPage: currentPage ?? this.currentPage,
       );
 
   @override
@@ -274,12 +446,20 @@ class SearchRecipeListState extends ListRecipeListState {
   List<Object?> get props => super.props + [query];
 
   @override
-  RecipeListState copyWith({bool? listView}) {
+  SearchRecipeListState copyWith({
+    bool? listView,
+    List<Recipe>? recipes,
+    Set<Tag>? tags,
+    bool? hasMore,
+    bool? isLoadingMore,
+    int? currentPage,
+    String? query,
+  }) {
     return SearchRecipeListState(
       listView: listView ?? this.listView,
-      query: query,
-      recipes: recipes,
-      tags: tags,
+      query: query ?? this.query,
+      recipes: recipes ?? this.recipes,
+      tags: tags ?? this.tags,
     );
   }
 }

--- a/kitchenowl/lib/cubits/recipe_list_cubit.dart
+++ b/kitchenowl/lib/cubits/recipe_list_cubit.dart
@@ -113,35 +113,19 @@ class RecipeListCubit extends Cubit<RecipeListState> {
       final merged = List<Recipe>.from(recipeList)..addAll(result.items);
       recipeList = merged;
 
-      final tags =
-          await TransactionHandler.getInstance().runTransaction(
+      final tags = await TransactionHandler.getInstance().runTransaction(
         TransactionTagGetAll(household: household),
         forceOffline: true,
       );
 
-      Set<Tag> filter = const {};
-      if (state is FilteredListRecipeListState) {
-        filter = (state as FilteredListRecipeListState).selectedTags;
-      }
-
       if (!isClosed) {
-        emit(filter.isNotEmpty
-            ? FilteredListRecipeListState(
-                recipes: _getFilteredRecipesCopy(merged, filter),
-                tags: tags,
-                selectedTags: filter,
-                allRecipes: merged,
-                listView: state.listView,
-                hasMore: result.hasMore,
-                currentPage: nextPage,
-              )
-            : ListRecipeListState(
-                recipes: merged,
-                tags: tags,
-                listView: state.listView,
-                hasMore: result.hasMore,
-                currentPage: nextPage,
-              ));
+        emit(ListRecipeListState(
+          recipes: merged,
+          tags: tags,
+          listView: state.listView,
+          hasMore: result.hasMore,
+          currentPage: nextPage,
+        ));
       }
     } catch (_) {
       // restore previous state without loading indicator

--- a/kitchenowl/lib/cubits/recipe_list_cubit.dart
+++ b/kitchenowl/lib/cubits/recipe_list_cubit.dart
@@ -7,7 +7,6 @@ import 'package:kitchenowl/models/tag.dart';
 import 'package:kitchenowl/services/api/api_service.dart';
 import 'package:kitchenowl/services/recipe_sync_service.dart';
 import 'package:kitchenowl/services/storage/storage.dart';
-import 'package:kitchenowl/services/storage/mem_storage.dart';
 import 'package:kitchenowl/services/transaction_handler.dart';
 import 'package:kitchenowl/services/transactions/recipe.dart';
 import 'package:kitchenowl/services/transactions/tag.dart';

--- a/kitchenowl/lib/l10n/app_en.arb
+++ b/kitchenowl/lib/l10n/app_en.arb
@@ -358,7 +358,6 @@
   "@recipeEdit": {},
   "@recipeEmpty": {},
   "@recipeEmptySearch": {},
-  "@recipeLoadError": {},
   "@recipeGoToInHousehold": {
     "placeholders": {
       "householdName": {
@@ -368,6 +367,7 @@
     }
   },
   "@recipeImageSelect": {},
+  "@recipeLoadError": {},
   "@recipeNew": {},
   "@recipeSource": {},
   "@recipes": {},
@@ -710,9 +710,9 @@
   "recipeEdit": "Edit recipe",
   "recipeEmpty": "No recipes, start by adding one!",
   "recipeEmptySearch": "No recipes found :(",
-  "recipeLoadError": "Could not load recipes. Please check your connection.",
   "recipeGoToInHousehold": "Already added, go to recipe in {householdName}",
   "recipeImageSelect": "Select a recipe image",
+  "recipeLoadError": "Could not load recipes. Please check your connection.",
   "recipeNew": "New recipe",
   "recipeSource": "Recipe source",
   "recipes": "Recipes",

--- a/kitchenowl/lib/l10n/app_en.arb
+++ b/kitchenowl/lib/l10n/app_en.arb
@@ -358,6 +358,7 @@
   "@recipeEdit": {},
   "@recipeEmpty": {},
   "@recipeEmptySearch": {},
+  "@recipeLoadError": {},
   "@recipeGoToInHousehold": {
     "placeholders": {
       "householdName": {
@@ -709,6 +710,7 @@
   "recipeEdit": "Edit recipe",
   "recipeEmpty": "No recipes, start by adding one!",
   "recipeEmptySearch": "No recipes found :(",
+  "recipeLoadError": "Could not load recipes. Please check your connection.",
   "recipeGoToInHousehold": "Already added, go to recipe in {householdName}",
   "recipeImageSelect": "Select a recipe image",
   "recipeNew": "New recipe",

--- a/kitchenowl/lib/models/recipe.dart
+++ b/kitchenowl/lib/models/recipe.dart
@@ -26,6 +26,10 @@ class Recipe extends Model {
   final int? householdId;
   final bool curated;
 
+  /// True when this instance contains full details (items, description).
+  /// False for slim list entries — fetch the full recipe before using items.
+  final bool hasFullDetails;
+
   /// The household this recipe belongs to, the contained field is not complete and should only be used for external recipes
   final Household? household;
 
@@ -48,6 +52,7 @@ class Recipe extends Model {
     this.householdId,
     this.household,
     this.curated = false,
+    this.hasFullDetails = true,
   });
 
   factory Recipe.fromJson(Map<String, dynamic> map) {
@@ -78,7 +83,7 @@ class Recipe extends Model {
     return Recipe(
       id: map['id'],
       name: map['name'],
-      description: map['description'],
+      description: map['description'] ?? '',
       isPlanned: map['planned'] ?? false,
       time: map['time'] ?? 0,
       cookTime: map['cook_time'] ?? 0,
@@ -96,6 +101,7 @@ class Recipe extends Model {
           ? Household.fromJson(map['household'])
           : null,
       curated: map['server_curated'] ?? false,
+      hasFullDetails: map.containsKey('items'),
     );
   }
 
@@ -115,6 +121,7 @@ class Recipe extends Model {
     Set<DateTime>? plannedCookingDates,
     int? householdId,
     bool? curated,
+    bool? hasFullDetails,
   }) =>
       Recipe(
         id: id,
@@ -135,6 +142,7 @@ class Recipe extends Model {
         visibility: visibility ?? this.visibility,
         householdId: householdId ?? this.householdId,
         household: this.household,
+        hasFullDetails: hasFullDetails ?? this.hasFullDetails,
       );
 
   Recipe withYields(int? yields) {
@@ -167,6 +175,7 @@ class Recipe extends Model {
         householdId,
         household,
         curated,
+        hasFullDetails,
       ];
 
   @override

--- a/kitchenowl/lib/pages/household_page/recipe_list.dart
+++ b/kitchenowl/lib/pages/household_page/recipe_list.dart
@@ -49,6 +49,20 @@ class _RecipeListPageState extends State<RecipeListPage> {
       getHeaderHeight: getHeaderHeight,
       getItemRowCount: getRowCount,
     );
+    // Attach the infinite-scroll trigger to the same controller used by
+    // CustomScrollView so the IndexBar and pagination share one controller.
+    scrollController.addListener(_onScroll);
+  }
+
+  void _onScroll() {
+    if (!mounted) return;
+    if (!scrollController.hasClients) return;
+    final cubit = BlocProvider.of<RecipeListCubit>(context);
+    final maxScroll = scrollController.position.maxScrollExtent;
+    final current = scrollController.offset;
+    if (maxScroll - current < 400) {
+      cubit.loadMore();
+    }
   }
 
   @override
@@ -174,6 +188,44 @@ class _RecipeListPageState extends State<RecipeListPage> {
                   );
                 }
 
+                // Error state
+                if (state is ErrorRecipeListState) {
+                  return Column(
+                    mainAxisAlignment: MainAxisAlignment.center,
+                    crossAxisAlignment: CrossAxisAlignment.center,
+                    children: [
+                      Align(
+                        key: headerKey,
+                        alignment: Alignment.topRight,
+                        child: Padding(
+                          padding: const EdgeInsets.only(right: 16),
+                          child: TrailingIconTextButton(
+                            onPressed: cubit.toggleView,
+                            text: state.listView
+                                ? AppLocalizations.of(context)!
+                                    .sortingAlphabetical
+                                : AppLocalizations.of(context)!.grid,
+                            icon: Icon(state.listView
+                                ? Icons.view_agenda_rounded
+                                : Icons.grid_view_rounded),
+                          ),
+                        ),
+                      ),
+                      const Spacer(),
+                      const Icon(Icons.cloud_off_rounded, size: 48),
+                      const SizedBox(height: 16),
+                      Text(AppLocalizations.of(context)!.recipeLoadError),
+                      const SizedBox(height: 16),
+                      ElevatedButton.icon(
+                        onPressed: cubit.refresh,
+                        icon: const Icon(Icons.refresh_rounded),
+                        label: Text(AppLocalizations.of(context)!.refresh),
+                      ),
+                      const Spacer(),
+                    ],
+                  );
+                }
+
                 if (state is! ListRecipeListState) {
                   return Column(
                     children: [
@@ -252,6 +304,14 @@ class _RecipeListPageState extends State<RecipeListPage> {
                                     ),
                                   ),
                           ),
+                          if (state.isLoadingMore)
+                            const SliverToBoxAdapter(
+                              child: Padding(
+                                padding: EdgeInsets.all(16),
+                                child: Center(
+                                    child: CircularProgressIndicator()),
+                              ),
+                            ),
                         ],
                       ),
                       if (state is! SearchRecipeListState)

--- a/kitchenowl/lib/services/api/recipe.dart
+++ b/kitchenowl/lib/services/api/recipe.dart
@@ -11,23 +11,9 @@ extension RecipeApi on ApiService {
 
   // ignore: constant_identifier_names
   static const Duration _TIMEOUT_SCRAPE = Duration(minutes: 3);
-  static const Duration _TIMEOUT_GET_RECIPES = Duration(seconds: 10);
   // Used by paginated and delta-sync requests that may transfer many pages.
   // ignore: constant_identifier_names
   static const Duration _TIMEOUT_GET_RECIPES_LONG = Duration(seconds: 60);
-
-  Future<List<Recipe>?> getRecipes(Household household) async {
-    final res = await get(
-      householdPath(household) + baseRoute,
-      queryParameters: {'details': 'slim'},
-      timeout: _TIMEOUT_GET_RECIPES,
-    );
-    if (res.statusCode != 200) return null;
-
-    final body = List.from(jsonDecode(res.body));
-
-    return body.map((e) => Recipe.fromJson(e)).toList();
-  }
 
   Future<List<Recipe>?> getRecipesFiltered(
     Household household,

--- a/kitchenowl/lib/services/api/recipe.dart
+++ b/kitchenowl/lib/services/api/recipe.dart
@@ -12,16 +12,15 @@ extension RecipeApi on ApiService {
   // ignore: constant_identifier_names
   static const Duration _TIMEOUT_SCRAPE = Duration(minutes: 3);
   static const Duration _TIMEOUT_GET_RECIPES = Duration(seconds: 10);
+  // Used by paginated and delta-sync requests that may transfer many pages.
+  // ignore: constant_identifier_names
   static const Duration _TIMEOUT_GET_RECIPES_LONG = Duration(seconds: 60);
 
-  Future<List<Recipe>?> getRecipes(
-    Household household, {
-    bool emptyCache = false,
-  }) async {
+  Future<List<Recipe>?> getRecipes(Household household) async {
     final res = await get(
       householdPath(household) + baseRoute,
       queryParameters: {'details': 'slim'},
-      timeout: emptyCache ? _TIMEOUT_GET_RECIPES_LONG : _TIMEOUT_GET_RECIPES,
+      timeout: _TIMEOUT_GET_RECIPES,
     );
     if (res.statusCode != 200) return null;
 
@@ -35,11 +34,12 @@ extension RecipeApi on ApiService {
     Set<Tag> filter, {
     bool slim = true,
   }) async {
-    final url = '${householdPath(household)}$baseRoute/filter'
-        '${slim ? '?details=slim' : ''}';
     final res = await post(
-      url,
-      jsonEncode({"filter": filter.map((e) => e.toString()).toList()}),
+      '${householdPath(household)}$baseRoute/filter',
+      jsonEncode({
+        "filter": filter.map((e) => e.toString()).toList(),
+        if (slim) "details": "slim",
+      }),
     );
     if (res.statusCode != 200) return null;
 

--- a/kitchenowl/lib/services/api/recipe.dart
+++ b/kitchenowl/lib/services/api/recipe.dart
@@ -12,11 +12,16 @@ extension RecipeApi on ApiService {
   // ignore: constant_identifier_names
   static const Duration _TIMEOUT_SCRAPE = Duration(minutes: 3);
   static const Duration _TIMEOUT_GET_RECIPES = Duration(seconds: 10);
+  static const Duration _TIMEOUT_GET_RECIPES_LONG = Duration(seconds: 60);
 
-  Future<List<Recipe>?> getRecipes(Household household) async {
+  Future<List<Recipe>?> getRecipes(
+    Household household, {
+    bool emptyCache = false,
+  }) async {
     final res = await get(
       householdPath(household) + baseRoute,
-      timeout: _TIMEOUT_GET_RECIPES,
+      queryParameters: {'details': 'slim'},
+      timeout: emptyCache ? _TIMEOUT_GET_RECIPES_LONG : _TIMEOUT_GET_RECIPES,
     );
     if (res.statusCode != 200) return null;
 
@@ -27,10 +32,13 @@ extension RecipeApi on ApiService {
 
   Future<List<Recipe>?> getRecipesFiltered(
     Household household,
-    Set<Tag> filter,
-  ) async {
+    Set<Tag> filter, {
+    bool slim = true,
+  }) async {
+    final url = '${householdPath(household)}$baseRoute/filter'
+        '${slim ? '?details=slim' : ''}';
     final res = await post(
-      '${householdPath(household)}$baseRoute/filter',
+      url,
       jsonEncode({"filter": filter.map((e) => e.toString()).toList()}),
     );
     if (res.statusCode != 200) return null;
@@ -53,11 +61,16 @@ extension RecipeApi on ApiService {
     return List.from(jsonDecode(res.body));
   }
 
-  Future<List<Recipe>?> searchRecipe(Household household, String query) async {
+  Future<List<Recipe>?> searchRecipe(
+    Household household,
+    String query, {
+    bool slim = true,
+  }) async {
     final res = await get(
       '${householdPath(household)}$baseRoute/search',
       queryParameters: {
         'query': query,
+        if (slim) 'details': 'slim',
       },
     );
     if (res.statusCode != 200) return null;
@@ -65,6 +78,59 @@ extension RecipeApi on ApiService {
     final body = List.from(jsonDecode(res.body));
 
     return body.map((e) => Recipe.fromJson(e)).toList();
+  }
+
+  Future<({List<Recipe> items, int total, bool hasMore})?> getRecipesPaginated(
+    Household household, {
+    int page = 0,
+    int perPage = 50,
+  }) async {
+    final res = await get(
+      householdPath(household) + baseRoute,
+      queryParameters: {
+        'details': 'slim',
+        'page': page.toString(),
+        'per_page': perPage.toString(),
+      },
+      timeout: _TIMEOUT_GET_RECIPES_LONG,
+    );
+    if (res.statusCode != 200) return null;
+
+    final body = jsonDecode(res.body) as Map<String, dynamic>;
+    final items = (body['items'] as List)
+        .map((e) => Recipe.fromJson(e as Map<String, dynamic>))
+        .toList();
+    final total = body['total'] as int;
+    final hasMore = (page + 1) * perPage < total;
+    return (items: items, total: total, hasMore: hasMore);
+  }
+
+  Future<({List<Recipe> recipes, List<int> deletedIds, bool hasMore, int serverTime})?> getRecipesDeltaSync(
+    Household household, {
+    int updatedAfter = 0,
+    int page = 0,
+    int perPage = 50,
+  }) async {
+    final res = await get(
+      '${householdPath(household)}$baseRoute/sync',
+      queryParameters: {
+        'updated_after': updatedAfter.toString(),
+        'page': page.toString(),
+        'per_page': perPage.toString(),
+      },
+      timeout: _TIMEOUT_GET_RECIPES_LONG,
+    );
+    if (res.statusCode != 200) return null;
+
+    final body = jsonDecode(res.body) as Map<String, dynamic>;
+    final recipes = (body['recipes'] as List)
+        .map((e) => Recipe.fromJson(e as Map<String, dynamic>))
+        .toList();
+    final deletedIds =
+        (body['deleted_ids'] as List).map((e) => e as int).toList();
+    final hasMore = body['has_more'] as bool;
+    final serverTime = (body['server_time'] as num).toInt();
+    return (recipes: recipes, deletedIds: deletedIds, hasMore: hasMore, serverTime: serverTime);
   }
 
   Future<(Recipe?, int)> getRecipe(Recipe recipe) async {

--- a/kitchenowl/lib/services/recipe_sync_service.dart
+++ b/kitchenowl/lib/services/recipe_sync_service.dart
@@ -17,6 +17,10 @@ class RecipeSyncService {
     return _instance!;
   }
 
+  // Per-household in-flight guard: prevents concurrent walks from interleaving
+  // and clobbering each other's final writeRecipes.
+  final Set<int> _inFlight = {};
+
   static String _cursorKey(Household household) =>
       'recipe_sync_cursor_${household.id}';
 
@@ -32,19 +36,24 @@ class RecipeSyncService {
   }
 
   /// Trigger an incremental background sync for [household].
-  /// Does nothing on web.
+  /// Does nothing on web. A second call while a walk is already in progress
+  /// for the same household is silently dropped.
   Future<void> sync(Household household) async {
     if (kIsWeb) return;
+    if (household.id == null) return;
+    if (_inFlight.contains(household.id)) return;
+    _inFlight.add(household.id!);
 
     try {
       final cursor = await _readCursor(household);
       int page = 0;
       bool hasMore = true;
+      bool completed = false;
       // Server timestamp from the first page response — used as new cursor to
       // avoid client-clock skew dropping updates written between pages.
       int? serverTimestamp;
 
-      // Load existing cached list to upsert into
+      // Load existing cached list to upsert into.
       final existing =
           await MemStorage.getInstance().readRecipes(household) ?? [];
       final byId = <int, Recipe>{
@@ -59,7 +68,7 @@ class RecipeSyncService {
           page: page,
           perPage: 50,
         );
-        if (result == null) break;
+        if (result == null) break; // network error mid-walk: abort, keep old cursor
 
         serverTimestamp ??= result.serverTime;
 
@@ -72,18 +81,23 @@ class RecipeSyncService {
 
         hasMore = result.hasMore;
         page++;
+        if (!hasMore) completed = true;
       }
 
       final merged = byId.values.toList()
         ..sort((a, b) => a.name.compareTo(b.name));
 
       await MemStorage.getInstance().writeRecipes(household, merged);
-      // Persist the server-provided timestamp to avoid client-clock skew.
-      if (serverTimestamp != null) {
+
+      // Only advance the cursor after a complete walk so a mid-sync abort
+      // retries the same window next time (upserts make re-processing safe).
+      if (completed && serverTimestamp != null) {
         await _writeCursor(household, serverTimestamp!);
       }
     } catch (_) {
       // Background sync errors are non-fatal; the UI continues with cached data.
+    } finally {
+      _inFlight.remove(household.id);
     }
   }
 }

--- a/kitchenowl/lib/services/recipe_sync_service.dart
+++ b/kitchenowl/lib/services/recipe_sync_service.dart
@@ -40,9 +40,8 @@ class RecipeSyncService {
   /// for the same household is silently dropped.
   Future<void> sync(Household household) async {
     if (kIsWeb) return;
-    if (household.id == null) return;
     if (_inFlight.contains(household.id)) return;
-    _inFlight.add(household.id!);
+    _inFlight.add(household.id);
 
     try {
       final cursor = await _readCursor(household);
@@ -92,7 +91,7 @@ class RecipeSyncService {
       // Only advance the cursor after a complete walk so a mid-sync abort
       // retries the same window next time (upserts make re-processing safe).
       if (completed && serverTimestamp != null) {
-        await _writeCursor(household, serverTimestamp!);
+        await _writeCursor(household, serverTimestamp);
       }
     } catch (_) {
       // Background sync errors are non-fatal; the UI continues with cached data.

--- a/kitchenowl/lib/services/recipe_sync_service.dart
+++ b/kitchenowl/lib/services/recipe_sync_service.dart
@@ -1,0 +1,89 @@
+import 'package:flutter/foundation.dart' show kIsWeb;
+import 'package:kitchenowl/models/household.dart';
+import 'package:kitchenowl/models/recipe.dart';
+import 'package:kitchenowl/services/api/api_service.dart';
+import 'package:kitchenowl/services/storage/mem_storage.dart';
+import 'package:kitchenowl/services/storage/storage.dart';
+
+/// Incrementally syncs full recipe details from the delta-sync endpoint.
+/// Only active on mobile (not web). Runs in the background after the slim
+/// list has been rendered so the UI stays responsive.
+class RecipeSyncService {
+  static RecipeSyncService? _instance;
+
+  RecipeSyncService._internal();
+  static RecipeSyncService getInstance() {
+    _instance ??= RecipeSyncService._internal();
+    return _instance!;
+  }
+
+  static String _cursorKey(Household household) =>
+      'recipe_sync_cursor_${household.id}';
+
+  Future<int> _readCursor(Household household) async {
+    final val = await PreferenceStorage.getInstance()
+        .readInt(key: _cursorKey(household));
+    return val ?? 0;
+  }
+
+  Future<void> _writeCursor(Household household, int timestamp) async {
+    await PreferenceStorage.getInstance()
+        .writeInt(key: _cursorKey(household), value: timestamp);
+  }
+
+  /// Trigger an incremental background sync for [household].
+  /// Does nothing on web.
+  Future<void> sync(Household household) async {
+    if (kIsWeb) return;
+
+    try {
+      final cursor = await _readCursor(household);
+      int page = 0;
+      bool hasMore = true;
+      // Server timestamp from the first page response — used as new cursor to
+      // avoid client-clock skew dropping updates written between pages.
+      int? serverTimestamp;
+
+      // Load existing cached list to upsert into
+      final existing =
+          await MemStorage.getInstance().readRecipes(household) ?? [];
+      final byId = <int, Recipe>{
+        for (final r in existing)
+          if (r.id != null) r.id!: r,
+      };
+
+      while (hasMore) {
+        final result = await ApiService.getInstance().getRecipesDeltaSync(
+          household,
+          updatedAfter: cursor,
+          page: page,
+          perPage: 50,
+        );
+        if (result == null) break;
+
+        serverTimestamp ??= result.serverTime;
+
+        for (final r in result.recipes) {
+          if (r.id != null) byId[r.id!] = r;
+        }
+        for (final deletedId in result.deletedIds) {
+          byId.remove(deletedId);
+        }
+
+        hasMore = result.hasMore;
+        page++;
+      }
+
+      final merged = byId.values.toList()
+        ..sort((a, b) => a.name.compareTo(b.name));
+
+      await MemStorage.getInstance().writeRecipes(household, merged);
+      // Persist the server-provided timestamp to avoid client-clock skew.
+      if (serverTimestamp != null) {
+        await _writeCursor(household, serverTimestamp!);
+      }
+    } catch (_) {
+      // Background sync errors are non-fatal; the UI continues with cached data.
+    }
+  }
+}

--- a/kitchenowl/lib/services/transactions/recipe.dart
+++ b/kitchenowl/lib/services/transactions/recipe.dart
@@ -2,11 +2,13 @@ import 'package:kitchenowl/models/household.dart';
 import 'package:kitchenowl/models/recipe.dart';
 import 'package:kitchenowl/models/tag.dart';
 import 'package:kitchenowl/services/api/api_service.dart';
-import 'package:kitchenowl/services/recipe_sync_service.dart';
 import 'package:kitchenowl/services/storage/mem_storage.dart';
 import 'package:kitchenowl/services/transaction.dart';
 import 'package:fuzzywuzzy/fuzzywuzzy.dart';
 
+// Offline-only: returns the locally synced full-detail store.
+// Online fetching goes through RecipeListCubit.getRecipesPaginated and
+// RecipeSyncService, never through this transaction.
 class TransactionRecipeGetRecipes extends Transaction<List<Recipe>> {
   final Household household;
 
@@ -22,19 +24,7 @@ class TransactionRecipeGetRecipes extends Transaction<List<Recipe>> {
   }
 
   @override
-  Future<List<Recipe>?> runOnline() async {
-    final cached = await MemStorage.getInstance().readRecipes(household);
-    final emptyCache = cached == null || cached.isEmpty;
-    final recipes = await ApiService.getInstance()
-        .getRecipes(household, emptyCache: emptyCache);
-    if (recipes != null) {
-      MemStorage.getInstance().writeRecipes(household, recipes);
-      // Kick off background full-detail sync (no-op on web)
-      RecipeSyncService.getInstance().sync(household);
-    }
-
-    return recipes;
-  }
+  Future<List<Recipe>?> runOnline() => runLocal();
 }
 
 class TransactionRecipeGetRecipesFiltered extends Transaction<List<Recipe>> {

--- a/kitchenowl/lib/services/transactions/recipe.dart
+++ b/kitchenowl/lib/services/transactions/recipe.dart
@@ -2,6 +2,7 @@ import 'package:kitchenowl/models/household.dart';
 import 'package:kitchenowl/models/recipe.dart';
 import 'package:kitchenowl/models/tag.dart';
 import 'package:kitchenowl/services/api/api_service.dart';
+import 'package:kitchenowl/services/recipe_sync_service.dart';
 import 'package:kitchenowl/services/storage/mem_storage.dart';
 import 'package:kitchenowl/services/transaction.dart';
 import 'package:fuzzywuzzy/fuzzywuzzy.dart';
@@ -22,9 +23,14 @@ class TransactionRecipeGetRecipes extends Transaction<List<Recipe>> {
 
   @override
   Future<List<Recipe>?> runOnline() async {
-    final recipes = await ApiService.getInstance().getRecipes(household);
+    final cached = await MemStorage.getInstance().readRecipes(household);
+    final emptyCache = cached == null || cached.isEmpty;
+    final recipes = await ApiService.getInstance()
+        .getRecipes(household, emptyCache: emptyCache);
     if (recipes != null) {
       MemStorage.getInstance().writeRecipes(household, recipes);
+      // Kick off background full-detail sync (no-op on web)
+      RecipeSyncService.getInstance().sync(household);
     }
 
     return recipes;


### PR DESCRIPTION
Closes #763

## Summary

- **Backend**: add `flask-compress` for gzip on JSON responses; `GET /household/<id>/recipe` now supports `?details=slim` (strips items/description, ~10× smaller payload), `?page=N&per_page=N` for pagination, and `?details=slim` on `/filter` and `/search`; new `GET /household/<id>/recipe/sync?updated_after=<unix>` delta-sync endpoint; new `recipe_tombstone` table populated on delete and consumed by the sync endpoint; `flask-compress` added to pyproject.toml
- **Flutter**: `RecipeListCubit` replaced full-list fetch with paginated slim load + infinite scroll; new `RecipeSyncService` runs a background incremental sync of full-detail recipes into `MemStorage` after the list renders; filter and search requests now send `details: slim` in the POST body; dead `getRecipes()` / `_TIMEOUT_GET_RECIPES` removed
- **Bug fixes**: `search_name` scoped to current household (was leaking across households); `load_extension` path no longer strips `.so` suffix (broke ICU on some platforms); SQLite WAL/SHM temp files added to `.gitignore`; `test_api_planner` cooking-date assertion made timezone-safe

## Test plan

- [ ] Backend: `cd backend && uv run pytest` — all tests pass
- [ ] Flutter: `flutter analyze` — no issues
- [ ] Recipe list loads on first open (slim page 0), then background sync fills full detail
- [ ] Infinite scroll loads additional pages
- [ ] Filter and search return correct results with slim payload
- [ ] Delta-sync returns only recipes changed since last sync; tombstones exclude deleted recipes
- [ ] ICU extension loads correctly (`load_extension` path fix)