### PR TITLE
fix(mcp): make the SSE transport usable

### DIFF
--- a/backend/app/controller/mcp_controller.py
+++ b/backend/app/controller/mcp_controller.py
@@ -1,12 +1,13 @@
 from __future__ import annotations
 
 import json
-import time
 import uuid
+from dataclasses import dataclass, field
 from datetime import datetime
+from queue import Empty, Queue
 from typing import Any, Callable
 
-from flask import Blueprint, Response, jsonify, request, stream_with_context
+from flask import Blueprint, Response, jsonify, request, url_for
 from flask_jwt_extended import current_user, jwt_required
 
 from app import db
@@ -30,14 +31,6 @@ from app.models.recipe import RecipeVisibility
 from app.service.recipe_scraping import scrape
 
 mcp = Blueprint("mcp", __name__)
-
-
-def _jsonrpc_ok(id_value: Any, result: Any):
-    return jsonify({"jsonrpc": "2.0", "id": id_value, "result": result})
-
-
-def _jsonrpc_err(id_value: Any, code: int, message: str):
-    return jsonify({"jsonrpc": "2.0", "id": id_value, "error": {"code": code, "message": message}})
 
 
 def _as_tool_result(payload: Any):
@@ -839,86 +832,179 @@ TOOLS: dict[str, tuple[dict[str, Any], Callable[[dict[str, Any]], Any]]] = {
 }
 
 
-def _handle_jsonrpc(body: dict[str, Any]):
+SUPPORTED_PROTOCOL_VERSIONS = ("2025-06-18", "2025-03-26", "2024-11-05")
+LATEST_PROTOCOL_VERSION = SUPPORTED_PROTOCOL_VERSIONS[0]
+
+SERVER_INSTRUCTIONS = (
+    "KitchenOwl manages households, each of which owns shopping lists, items, "
+    "recipes, tags, meal plans and expenses. Nearly every tool is scoped to a "
+    "household, so call list_households first and reuse the id you get back."
+)
+
+SSE_KEEPALIVE_SECONDS = 15
+
+
+def _dispatch(body: Any) -> Any:
+    # Returns the response to send back, or None for notifications, which the
+    # protocol requires be left unanswered.
+    if isinstance(body, list):
+        responses = [r for r in (_dispatch(item) for item in body) if r is not None]
+        return responses or None
+
+    if not isinstance(body, dict):
+        return {
+            "jsonrpc": "2.0",
+            "id": None,
+            "error": {"code": -32600, "message": "Invalid Request"},
+        }
+
     id_value = body.get("id")
     method = body.get("method")
     params = body.get("params") or {}
+    is_notification = "id" not in body
 
     try:
         if method == "initialize":
-            return _jsonrpc_ok(
-                id_value,
-                {
-                    "protocolVersion": "2024-11-05",
-                    "capabilities": {"tools": {}},
-                    "serverInfo": {"name": "kitchenowl-mcp", "version": str(BACKEND_VERSION)},
-                },
+            requested = params.get("protocolVersion")
+            version = (
+                requested
+                if requested in SUPPORTED_PROTOCOL_VERSIONS
+                else LATEST_PROTOCOL_VERSION
             )
-
-        if method == "notifications/initialized":
-            return ("", 204)
-
-        if method == "ping":
-            return _jsonrpc_ok(id_value, {})
-
-        if method == "tools/list":
-            tools = []
-            for name, (schema, _) in TOOLS.items():
-                tools.append(
+            result = {
+                "protocolVersion": version,
+                "capabilities": {"tools": {"listChanged": False}},
+                "serverInfo": {
+                    "name": "kitchenowl-mcp",
+                    "version": str(BACKEND_VERSION),
+                },
+                "instructions": SERVER_INSTRUCTIONS,
+            }
+        elif method is not None and method.startswith("notifications/"):
+            return None
+        elif method == "ping":
+            result = {}
+        elif method == "tools/list":
+            result = {
+                "tools": [
                     {
                         "name": name,
                         "description": f"KitchenOwl tool: {name}",
                         "inputSchema": schema,
                     }
-                )
-            return _jsonrpc_ok(id_value, {"tools": tools})
-
-        if method == "tools/call":
+                    for name, (schema, _) in TOOLS.items()
+                ]
+            }
+        elif method == "tools/call":
             name = params.get("name")
             args = params.get("arguments") or {}
             if name not in TOOLS:
-                return _jsonrpc_err(id_value, -32601, f"Unknown tool: {name}")
+                return None if is_notification else _rpc_error(
+                    id_value, -32602, f"Unknown tool: {name}"
+                )
             _, handler = TOOLS[name]
-            result = handler(args)
+            result = _as_tool_result(handler(args))
             db.session.commit()
-            return _jsonrpc_ok(id_value, _as_tool_result(result))
-
-        return _jsonrpc_err(id_value, -32601, f"Method not found: {method}")
+        else:
+            return None if is_notification else _rpc_error(
+                id_value, -32601, f"Method not found: {method}"
+            )
     except Exception as e:
         db.session.rollback()
-        return _jsonrpc_err(id_value, -32000, str(e))
+        return None if is_notification else _rpc_error(id_value, -32000, str(e))
+
+    return None if is_notification else {"jsonrpc": "2.0", "id": id_value, "result": result}
 
 
-@mcp.route("", methods=["GET"])
-@mcp.route("/sse", methods=["GET"])
-@jwt_required()
-def mcp_sse():
-    session_id = str(uuid.uuid4())
+def _rpc_error(id_value: Any, code: int, message: str) -> dict[str, Any]:
+    return {"jsonrpc": "2.0", "id": id_value, "error": {"code": code, "message": message}}
 
-    def generate():
-        endpoint = request.url_root.rstrip("/") + f"/mcp/messages/{session_id}"
-        yield f"event: endpoint\ndata: {endpoint}\n\n"
-        while True:
-            yield "event: ping\ndata: {}\n\n"
-            time.sleep(15)
 
-    return Response(
-        stream_with_context(generate()),
-        mimetype="text/event-stream",
-        headers={"Cache-Control": "no-cache", "X-Accel-Buffering": "no"},
-    )
+# Streamable HTTP. Stateless: no session id is issued, so this transport keeps
+# working across multiple uWSGI workers.
 
 
 @mcp.route("", methods=["POST"])
 @jwt_required()
 def mcp_post():
-    body = request.get_json(silent=True) or {}
-    return _handle_jsonrpc(body)
+    response = _dispatch(request.get_json(silent=True))
+    if response is None:
+        return "", 202
+    return jsonify(response)
+
+
+@mcp.route("", methods=["GET", "DELETE"])
+@jwt_required()
+def mcp_stream_unsupported():
+    # Nothing to push outside a request and no session to tear down; the spec
+    # allows 405 for both.
+    return Response(status=405, headers={"Allow": "POST"})
+
+
+# HTTP+SSE. Both halves of a session must be served by the same process, so this
+# registry is deliberately per-worker.
+
+
+@dataclass
+class _SseSession:
+    user_id: int
+    id: str = field(default_factory=lambda: str(uuid.uuid4()))
+    outbox: Queue = field(default_factory=Queue)
+
+
+_sse_sessions: dict[str, _SseSession] = {}
+
+
+@mcp.route("/sse", methods=["GET"])
+@jwt_required()
+def mcp_sse():
+    session = _SseSession(user_id=current_user.id)
+    _sse_sessions[session.id] = session
+
+    # Relative, so it survives a reverse proxy that request.url_root would not.
+    endpoint = f"{url_for('mcp.mcp_messages')}?session_id={session.id}"
+
+    def generate():
+        try:
+            yield f"event: endpoint\ndata: {endpoint}\n\n"
+            while True:
+                try:
+                    message = session.outbox.get(timeout=SSE_KEEPALIVE_SECONDS)
+                except Empty:
+                    yield ": keep-alive\n\n"
+                    continue
+                yield "event: message\ndata: {}\n\n".format(
+                    json.dumps(message, ensure_ascii=False, default=str)
+                )
+        finally:
+            _sse_sessions.pop(session.id, None)
+
+    return Response(
+        generate(),
+        mimetype="text/event-stream",
+        headers={
+            "Cache-Control": "no-cache, no-transform",
+            "Connection": "keep-alive",
+            "X-Accel-Buffering": "no",
+        },
+    )
 
 
 @mcp.route("/messages", methods=["POST"])
 @mcp.route("/messages/<session_id>", methods=["POST"])
 @jwt_required()
 def mcp_messages(session_id: str | None = None):
-    body = request.get_json(silent=True) or {}
-    return _handle_jsonrpc(body)
+    session_id = session_id or request.args.get("session_id")
+    session = _sse_sessions.get(session_id) if session_id else None
+
+    if session is None:
+        return jsonify({"error": "Unknown or expired session"}), 404
+    if session.user_id != current_user.id:
+        return jsonify({"error": "Session belongs to a different user"}), 403
+
+    response = _dispatch(request.get_json(silent=True))
+    if response is not None:
+        session.outbox.put(response)
+
+    # The reply travels over the SSE stream, not this response.
+    return "", 202

--- a/backend/tests/api/test_api_mcp_transport.py
+++ b/backend/tests/api/test_api_mcp_transport.py
@@ -1,0 +1,186 @@
+import json
+
+import pytest
+
+from app.controller.mcp_controller import (
+    LATEST_PROTOCOL_VERSION,
+    SUPPORTED_PROTOCOL_VERSIONS,
+    _SseSession,
+    _sse_sessions,
+)
+
+
+def _rpc(client, method, params=None, id_=1):
+    payload = {"jsonrpc": "2.0", "id": id_, "method": method}
+    if params is not None:
+        payload["params"] = params
+    return client.post("/mcp", json=payload)
+
+
+def _read_sse_events(response, count):
+    # Pulls `count` (event, data) pairs off a streamed response, skipping
+    # keep-alive comments.
+    events = []
+    buffer = ""
+    for chunk in response.response:
+        buffer += chunk.decode()
+        while "\n\n" in buffer:
+            raw, buffer = buffer.split("\n\n", 1)
+            event, data = None, None
+            for line in raw.splitlines():
+                if line.startswith("event:"):
+                    event = line[len("event:"):].strip()
+                elif line.startswith("data:"):
+                    data = line[len("data:"):].strip()
+            if event is not None:
+                events.append((event, data))
+            if len(events) >= count:
+                return events
+    return events
+
+
+def test_initialize_echoes_supported_protocol_version(user_client_with_household):
+    for version in SUPPORTED_PROTOCOL_VERSIONS:
+        res = _rpc(user_client_with_household, "initialize", {"protocolVersion": version})
+        assert res.status_code == 200
+        assert res.get_json()["result"]["protocolVersion"] == version
+
+
+def test_initialize_falls_back_to_latest_for_unknown_version(user_client_with_household):
+    res = _rpc(user_client_with_household, "initialize", {"protocolVersion": "1999-01-01"})
+    assert res.get_json()["result"]["protocolVersion"] == LATEST_PROTOCOL_VERSION
+
+
+def test_initialize_reports_server_info_and_instructions(user_client_with_household):
+    result = _rpc(user_client_with_household, "initialize", {}).get_json()["result"]
+    assert result["serverInfo"]["name"] == "kitchenowl-mcp"
+    assert result["capabilities"]["tools"] is not None
+    assert result["instructions"]
+
+
+def test_notifications_get_202_and_no_body(user_client_with_household):
+    res = user_client_with_household.post(
+        "/mcp", json={"jsonrpc": "2.0", "method": "notifications/initialized"}
+    )
+    assert res.status_code == 202
+    assert res.data == b""
+
+
+def test_ping_roundtrip(user_client_with_household):
+    body = _rpc(user_client_with_household, "ping").get_json()
+    assert body["result"] == {}
+    assert body["id"] == 1
+
+
+def test_unknown_method_is_a_protocol_error(user_client_with_household):
+    body = _rpc(user_client_with_household, "does/not/exist").get_json()
+    assert body["error"]["code"] == -32601
+
+
+def test_batch_request_returns_one_response_per_request(user_client_with_household):
+    res = user_client_with_household.post(
+        "/mcp",
+        json=[
+            {"jsonrpc": "2.0", "id": 1, "method": "ping"},
+            {"jsonrpc": "2.0", "method": "notifications/initialized"},
+            {"jsonrpc": "2.0", "id": 2, "method": "ping"},
+        ],
+    )
+    body = res.get_json()
+    assert isinstance(body, list)
+    # The notification must not produce a response.
+    assert [r["id"] for r in body] == [1, 2]
+
+
+def test_malformed_body_is_an_invalid_request(user_client_with_household):
+    body = user_client_with_household.post("/mcp", json="not-an-object").get_json()
+    assert body["error"]["code"] == -32600
+
+
+def test_get_and_delete_on_root_are_405(user_client_with_household):
+    for method in ("get", "delete"):
+        res = getattr(user_client_with_household, method)("/mcp")
+        assert res.status_code == 405
+        assert res.headers["Allow"] == "POST"
+
+
+def test_transport_requires_authentication(client):
+    res = client.post("/mcp", json={"jsonrpc": "2.0", "id": 1, "method": "ping"})
+    assert res.status_code == 401
+
+
+@pytest.fixture
+def sse_session(user_client_with_household):
+    _sse_sessions.clear()
+    res = user_client_with_household.get("/mcp/sse")
+    assert res.status_code == 200
+    assert res.mimetype == "text/event-stream"
+
+    (event, data), = _read_sse_events(res, 1)
+    assert event == "endpoint"
+
+    yield data, data.split("session_id=")[1], res
+    res.close()
+    _sse_sessions.clear()
+
+
+def test_sse_announces_a_relative_endpoint(sse_session):
+    endpoint, session_id, _ = sse_session
+    assert endpoint.startswith("/mcp/messages?session_id=")
+    assert session_id in _sse_sessions
+
+
+def test_sse_post_is_accepted_and_reply_arrives_on_the_stream(
+    sse_session, user_client_with_household
+):
+    endpoint, _, stream = sse_session
+
+    res = user_client_with_household.post(
+        endpoint, json={"jsonrpc": "2.0", "id": 7, "method": "ping"}
+    )
+    assert res.status_code == 202
+    assert res.data == b""
+
+    (event, data), = _read_sse_events(stream, 1)
+    assert event == "message"
+    assert json.loads(data) == {"jsonrpc": "2.0", "id": 7, "result": {}}
+
+
+def test_sse_notification_produces_no_stream_message(
+    sse_session, user_client_with_household
+):
+    endpoint, session_id, _ = sse_session
+
+    res = user_client_with_household.post(
+        endpoint, json={"jsonrpc": "2.0", "method": "notifications/initialized"}
+    )
+    assert res.status_code == 202
+    assert _sse_sessions[session_id].outbox.empty()
+
+
+def test_post_to_unknown_session_is_404(user_client_with_household):
+    res = user_client_with_household.post(
+        "/mcp/messages?session_id=nope", json={"jsonrpc": "2.0", "id": 1, "method": "ping"}
+    )
+    assert res.status_code == 404
+
+
+def test_post_without_session_id_is_404(user_client_with_household):
+    res = user_client_with_household.post(
+        "/mcp/messages", json={"jsonrpc": "2.0", "id": 1, "method": "ping"}
+    )
+    assert res.status_code == 404
+
+
+def test_cannot_push_into_another_users_session(user_client_with_household):
+    _sse_sessions.clear()
+    foreign = _SseSession(user_id=99999)
+    _sse_sessions[foreign.id] = foreign
+
+    res = user_client_with_household.post(
+        f"/mcp/messages?session_id={foreign.id}",
+        json={"jsonrpc": "2.0", "id": 1, "method": "ping"},
+    )
+    assert res.status_code == 403
+    assert foreign.outbox.empty()
+    _sse_sessions.clear()


### PR DESCRIPTION
The SSE transport added in #1020 never worked. The stream opens, sends the `endpoint` event, then only pings. It never emits `event: message`. Replies come back in the POST body instead, but under the 2024-11-05 spec the client reads them off the stream, so any conforming client hangs after `initialize`. The session id is generated but never stored or looked up.

This tracks sessions per worker, delivers replies over the stream, and returns 202 from the POST. A session can only be written to by the user who opened it. The announced endpoint is now relative so it survives a reverse proxy.

Also adds Streamable HTTP on `POST /mcp`, stateless so it works across multiple workers, and negotiates `protocolVersion` rather than always answering `2024-11-05`.

Tested against Claude Code over both transports. 16 new tests.