### PR TITLE
feat(mcp): expand the MCP server, describe and annotate its tools

### DIFF
--- a/backend/app/controller/mcp_controller.py
+++ b/backend/app/controller/mcp_controller.py
@@ -7,12 +7,17 @@ from datetime import datetime
 from queue import Empty, Queue
 from typing import Any, Callable
 
-from flask import Blueprint, Response, jsonify, request, url_for
+from flask import Blueprint, Response, current_app, jsonify, request, url_for
 from flask_jwt_extended import current_user, jwt_required
 
 from app import db
 from app.config import BACKEND_VERSION
-from app.errors import NotFoundRequest
+from app.errors import (
+    ForbiddenRequest,
+    InvalidUsage,
+    NotFoundRequest,
+    UnauthorizedRequest,
+)
 from app.models import (
     History,
     Household,
@@ -33,11 +38,72 @@ from app.service.recipe_scraping import scrape
 mcp = Blueprint("mcp", __name__)
 
 
+DEFAULT_PAGE_SIZE = 50
+MAX_PAGE_SIZE = 200
+
+
 def _as_tool_result(payload: Any):
     text = json.dumps(payload, ensure_ascii=False, default=str)
     return {
         "content": [{"type": "text", "text": text}],
         "structuredContent": payload,
+    }
+
+
+def _as_tool_error(message: str):
+    return {"content": [{"type": "text", "text": message}], "isError": True}
+
+
+def _tool_error_message(error: Exception) -> str:
+    if isinstance(error, (NotFoundRequest, ForbiddenRequest, UnauthorizedRequest, InvalidUsage)):
+        return error.message
+    if isinstance(error, KeyError):
+        return f"Missing required argument: {error.args[0]}"
+    if isinstance(error, (ValueError, TypeError)):
+        return str(error)
+    current_app.logger.exception("MCP tool failed")
+    return "The tool failed unexpectedly. The error has been logged."
+
+
+def _page_args(args: dict[str, Any]) -> tuple[int, int]:
+    limit = min(max(int(args.get("limit", DEFAULT_PAGE_SIZE)), 1), MAX_PAGE_SIZE)
+    return limit, max(int(args.get("offset", 0)), 0)
+
+
+def _paginate_query(query, args: dict[str, Any], serialize) -> dict[str, Any]:
+    limit, offset = _page_args(args)
+    total = query.count()
+    rows = query.limit(limit).offset(offset).all()
+    return {
+        "items": [serialize(r) for r in rows],
+        "total": total,
+        "offset": offset,
+        "has_more": offset + len(rows) < total,
+    }
+
+
+def _paginate_list(rows: list, args: dict[str, Any], serialize) -> dict[str, Any]:
+    limit, offset = _page_args(args)
+    page = rows[offset : offset + limit]
+    return {
+        "items": [serialize(r) for r in page],
+        "total": len(rows),
+        "offset": offset,
+        "has_more": offset + len(page) < len(rows),
+    }
+
+
+def _recipe_summary(recipe: Recipe) -> dict[str, Any]:
+    # Deliberately omits description, items and the nested household that
+    # obj_to_full_dict carries; get_recipe returns those on demand.
+    return {
+        "id": recipe.id,
+        "name": recipe.name,
+        "time": recipe.time,
+        "cook_time": recipe.cook_time,
+        "prep_time": recipe.prep_time,
+        "yields": recipe.yields,
+        "tags": [t.tag.name for t in recipe.tags],
     }
 
 
@@ -47,15 +113,16 @@ def _require_household_access(household_id: int):
         raise NotFoundRequest()
 
 
-def _tool_list_households(_args: dict[str, Any]) -> Any:
+def _tool_list_households(args: dict[str, Any]) -> Any:
     members = HouseholdMember.find_by_user(current_user.id)
-    return {"items": [m.household.obj_to_dict() for m in members]}
+    return _paginate_list(members, args, lambda m: m.household.obj_to_dict())
 
 
 def _tool_list_shoppinglists(args: dict[str, Any]) -> Any:
     household_id = int(args["household_id"])
     _require_household_access(household_id)
-    return {"items": [e.obj_to_dict() for e in Shoppinglist.all_from_household(household_id)]}
+    lists = Shoppinglist.all_from_household(household_id)
+    return _paginate_list(lists, args, lambda e: e.obj_to_dict())
 
 
 def _tool_list_shoppinglist_items(args: dict[str, Any]) -> Any:
@@ -64,12 +131,10 @@ def _tool_list_shoppinglist_items(args: dict[str, Any]) -> Any:
     if not shoppinglist:
         raise NotFoundRequest()
     shoppinglist.checkAuthorized()
-    items = (
-        ShoppinglistItems.query.filter(ShoppinglistItems.shoppinglist_id == list_id)
-        .join(ShoppinglistItems.item)
-        .all()
-    )
-    return {"items": [e.obj_to_item_dict() for e in items]}
+    query = ShoppinglistItems.query.filter(
+        ShoppinglistItems.shoppinglist_id == list_id
+    ).join(ShoppinglistItems.item)
+    return _paginate_query(query, args, lambda e: e.obj_to_item_dict())
 
 
 def _tool_add_item_by_name(args: dict[str, Any]) -> Any:
@@ -101,22 +166,20 @@ def _tool_add_item_by_name(args: dict[str, Any]) -> Any:
 def _tool_list_recipes(args: dict[str, Any]) -> Any:
     household_id = int(args["household_id"])
     _require_household_access(household_id)
-    recipes = Recipe.query.filter(Recipe.household_id == household_id).order_by(Recipe.name).all()
-    return {"items": [r.obj_to_full_dict() for r in recipes]}
+    query = Recipe.query.filter(Recipe.household_id == household_id).order_by(Recipe.name)
+    return _paginate_query(query, args, _recipe_summary)
 
 
 def _tool_search_recipes(args: dict[str, Any]) -> Any:
     household_id = int(args["household_id"])
     query = str(args["query"]).strip()
     _require_household_access(household_id)
-    recipes = (
+    matches = (
         Recipe.query.filter(Recipe.household_id == household_id)
         .filter(Recipe.name.ilike(f"%{query}%"))
         .order_by(Recipe.name)
-        .limit(50)
-        .all()
     )
-    return {"items": [r.obj_to_full_dict() for r in recipes]}
+    return _paginate_query(matches, args, _recipe_summary)
 
 
 def _tool_create_recipe(args: dict[str, Any]) -> Any:
@@ -208,15 +271,14 @@ def _tool_list_items(args: dict[str, Any]) -> Any:
     q = Item.query.filter(Item.household_id == household_id)
     if search:
         q = q.filter(Item.name.ilike(f"%{search}%"))
-    items = q.order_by(Item.name).limit(100).all()
-    return {"items": [i.obj_to_dict() for i in items]}
+    return _paginate_query(q.order_by(Item.name), args, lambda i: i.obj_to_dict())
 
 
 def _tool_list_tags(args: dict[str, Any]) -> Any:
     household_id = int(args["household_id"])
     _require_household_access(household_id)
-    tags = Tag.query.filter(Tag.household_id == household_id).order_by(Tag.name).all()
-    return {"items": [t.obj_to_full_dict() for t in tags]}
+    query = Tag.query.filter(Tag.household_id == household_id).order_by(Tag.name)
+    return _paginate_query(query, args, lambda t: t.obj_to_full_dict())
 
 
 def _tool_create_tag(args: dict[str, Any]) -> Any:
@@ -419,8 +481,9 @@ def _tool_list_expenses(args: dict[str, Any]) -> Any:
     q = Expense.query.filter(Expense.household_id == household_id)
     if search:
         q = q.filter(Expense.name.ilike(f"%{search}%"))
-    expenses = q.order_by(Expense.date.desc()).limit(50).all()
-    return {"items": [e.obj_to_full_dict() for e in expenses]}
+    return _paginate_query(
+        q.order_by(Expense.date.desc()), args, lambda e: e.obj_to_full_dict()
+    )
 
 
 def _tool_create_expense(args: dict[str, Any]) -> Any:
@@ -504,7 +567,7 @@ def _tool_list_planner(args: dict[str, Any]) -> Any:
     household_id = int(args["household_id"])
     _require_household_access(household_id)
     plans = Planner.all_from_household(household_id)
-    return {"items": [p.obj_to_full_dict() for p in plans]}
+    return _paginate_list(plans, args, lambda p: p.obj_to_full_dict())
 
 
 def _tool_scrape_recipe(args: dict[str, Any]) -> Any:
@@ -522,312 +585,501 @@ def _tool_scrape_recipe(args: dict[str, Any]) -> Any:
     return res
 
 
-TOOLS: dict[str, tuple[dict[str, Any], Callable[[dict[str, Any]], Any]]] = {
-    "list_households": (
-        {"type": "object", "properties": {}},
-        _tool_list_households,
-    ),
-    "list_shoppinglists": (
-        {
-            "type": "object",
-            "properties": {"household_id": {"type": "integer"}},
-            "required": ["household_id"],
+@dataclass(frozen=True)
+class Tool:
+    title: str
+    description: str
+    schema: dict[str, Any]
+    handler: Callable[[dict[str, Any]], Any]
+    read_only: bool = False
+    destructive: bool = False
+    idempotent: bool = False
+    open_world: bool = False
+
+    def annotations(self) -> dict[str, Any]:
+        return {
+            "title": self.title,
+            "readOnlyHint": self.read_only,
+            "destructiveHint": self.destructive,
+            "idempotentHint": self.idempotent,
+            "openWorldHint": self.open_world,
+        }
+
+
+def _schema(properties: dict[str, Any], required: tuple[str, ...] = ()) -> dict[str, Any]:
+    return {"type": "object", "properties": properties, "required": list(required)}
+
+
+def _paged(properties: dict[str, Any]) -> dict[str, Any]:
+    return {
+        **properties,
+        "limit": {
+            "type": "integer",
+            "minimum": 1,
+            "maximum": MAX_PAGE_SIZE,
+            "description": f"Rows to return, {1}-{MAX_PAGE_SIZE}, default {DEFAULT_PAGE_SIZE}.",
         },
-        _tool_list_shoppinglists,
-    ),
-    "list_shoppinglist_items": (
-        {
-            "type": "object",
-            "properties": {"list_id": {"type": "integer"}},
-            "required": ["list_id"],
+        "offset": {
+            "type": "integer",
+            "minimum": 0,
+            "description": "Rows to skip. Use with the has_more flag to page through results.",
         },
-        _tool_list_shoppinglist_items,
+    }
+
+
+P_HOUSEHOLD = {
+    "type": "integer",
+    "description": "Household id, as returned by list_households.",
+}
+P_LIST = {
+    "type": "integer",
+    "description": "Shopping list id, as returned by list_shoppinglists.",
+}
+P_RECIPE = {"type": "integer", "description": "Recipe id, as returned by list_recipes."}
+P_QUANTITY = {
+    "type": "string",
+    "description": (
+        "Free-text quantity shown next to the item, e.g. '2 kg', '500 g', '3 x'. "
+        "Leave empty if no quantity is needed."
     ),
-    "add_item_by_name": (
-        {
-            "type": "object",
-            "properties": {
-                "list_id": {"type": "integer"},
-                "name": {"type": "string"},
-                "description": {"type": "string"},
+}
+P_COOKING_DATE = {
+    "type": "string",
+    "description": "Day the recipe is planned for, as an ISO-8601 date-time.",
+}
+P_VISIBILITY = {
+    "type": "integer",
+    "enum": [0, 1, 2],
+    "description": "0 private to the household, 1 shared by link, 2 public.",
+}
+
+RECIPE_FIELDS = {
+    "name": {"type": "string", "description": "Recipe name, truncated to 128 characters."},
+    "description": {
+        "type": "string",
+        "description": "The method, as markdown. This is the body of the recipe.",
+    },
+    "time": {"type": "integer", "description": "Total time in minutes."},
+    "cook_time": {"type": "integer", "description": "Cooking time in minutes."},
+    "prep_time": {"type": "integer", "description": "Preparation time in minutes."},
+    "yields": {"type": "integer", "description": "Number of servings the recipe makes."},
+    "source": {"type": "string", "description": "URL or book the recipe came from."},
+    "visibility": P_VISIBILITY,
+}
+
+
+TOOLS: dict[str, Tool] = {
+    "list_households": Tool(
+        title="List households",
+        description=(
+            "List the households you are a member of. Almost every other tool needs a "
+            "household_id, so call this first and reuse the id."
+        ),
+        schema=_schema(_paged({})),
+        handler=_tool_list_households,
+        read_only=True,
+        idempotent=True,
+    ),
+    "list_shoppinglists": Tool(
+        title="List shopping lists",
+        description=(
+            "List the shopping lists belonging to a household. Most households have a "
+            "single list named 'Default'."
+        ),
+        schema=_schema(_paged({"household_id": P_HOUSEHOLD}), ("household_id",)),
+        handler=_tool_list_shoppinglists,
+        read_only=True,
+        idempotent=True,
+    ),
+    "list_shoppinglist_items": Tool(
+        title="List items to buy",
+        description=(
+            "List what is currently on a shopping list, i.e. what still needs buying. "
+            "Each entry carries the item name and a free-text description holding the "
+            "quantity. To see the household's full item vocabulary instead, use list_items."
+        ),
+        schema=_schema(_paged({"list_id": P_LIST}), ("list_id",)),
+        handler=_tool_list_shoppinglist_items,
+        read_only=True,
+        idempotent=True,
+    ),
+    "add_item_by_name": Tool(
+        title="Add item to shopping list",
+        description=(
+            "Put an item on a shopping list, creating it in the household if it is not "
+            "already known. Adding an item that is already on the list changes nothing, "
+            "so this is safe to retry."
+        ),
+        schema=_schema(
+            {
+                "list_id": P_LIST,
+                "name": {
+                    "type": "string",
+                    "description": "Item name on its own, e.g. 'milk'. Put quantities in description.",
+                },
+                "description": P_QUANTITY,
             },
-            "required": ["list_id", "name"],
-        },
-        _tool_add_item_by_name,
+            ("list_id", "name"),
+        ),
+        handler=_tool_add_item_by_name,
+        idempotent=True,
     ),
-    "list_recipes": (
-        {
-            "type": "object",
-            "properties": {"household_id": {"type": "integer"}},
-            "required": ["household_id"],
-        },
-        _tool_list_recipes,
-    ),
-    "search_recipes": (
-        {
-            "type": "object",
-            "properties": {
-                "household_id": {"type": "integer"},
-                "query": {"type": "string"},
+    "remove_item_from_list": Tool(
+        title="Remove item from shopping list",
+        description=(
+            "Take an item off a shopping list, typically once it has been bought. "
+            "Identify it by item_id or by name. The item itself is kept in the "
+            "household so it can be added again later."
+        ),
+        schema=_schema(
+            {
+                "list_id": P_LIST,
+                "item_id": {"type": "integer", "description": "Item id. Preferred over name."},
+                "name": {"type": "string", "description": "Item name, if the id is unknown."},
             },
-            "required": ["household_id", "query"],
-        },
-        _tool_search_recipes,
+            ("list_id",),
+        ),
+        handler=_tool_remove_item_from_list,
+        destructive=True,
+        idempotent=True,
     ),
-    "create_recipe": (
-        {
-            "type": "object",
-            "properties": {
-                "household_id": {"type": "integer"},
-                "name": {"type": "string"},
-                "description": {"type": "string"},
-                "time": {"type": "integer"},
-                "cook_time": {"type": "integer"},
-                "prep_time": {"type": "integer"},
-                "yields": {"type": "integer"},
-                "source": {"type": "string"},
-                "visibility": {"type": "integer", "enum": [0, 1, 2]},
+    "create_shoppinglist": Tool(
+        title="Create shopping list",
+        description="Create an additional shopping list in a household.",
+        schema=_schema(
+            {
+                "household_id": P_HOUSEHOLD,
+                "name": {"type": "string", "description": "List name, e.g. 'Weekly shop'."},
+            },
+            ("household_id", "name"),
+        ),
+        handler=_tool_create_shoppinglist,
+    ),
+    "delete_shoppinglist": Tool(
+        title="Delete shopping list",
+        description=(
+            "Delete a shopping list and everything on it. The household's default list "
+            "cannot be deleted."
+        ),
+        schema=_schema({"list_id": P_LIST}, ("list_id",)),
+        handler=_tool_delete_shoppinglist,
+        destructive=True,
+    ),
+    "list_items": Tool(
+        title="List known items",
+        description=(
+            "List the items a household knows about, whether or not they are on a list "
+            "right now. Useful for matching a vague request to an existing item instead "
+            "of creating a near-duplicate."
+        ),
+        schema=_schema(
+            _paged(
+                {
+                    "household_id": P_HOUSEHOLD,
+                    "search": {
+                        "type": "string",
+                        "description": "Case-insensitive substring filter on the item name.",
+                    },
+                }
+            ),
+            ("household_id",),
+        ),
+        handler=_tool_list_items,
+        read_only=True,
+        idempotent=True,
+    ),
+    "list_recipes": Tool(
+        title="List recipes",
+        description=(
+            "List a household's recipes as summaries: id, name, times, yields and tags. "
+            "Ingredients and method are omitted, so call get_recipe for a specific one."
+        ),
+        schema=_schema(_paged({"household_id": P_HOUSEHOLD}), ("household_id",)),
+        handler=_tool_list_recipes,
+        read_only=True,
+        idempotent=True,
+    ),
+    "search_recipes": Tool(
+        title="Search recipes",
+        description=(
+            "Find recipes whose name contains the query, case-insensitive. Returns the "
+            "same summaries as list_recipes. Matches names only, not ingredients."
+        ),
+        schema=_schema(
+            _paged(
+                {
+                    "household_id": P_HOUSEHOLD,
+                    "query": {"type": "string", "description": "Substring to look for in recipe names."},
+                }
+            ),
+            ("household_id", "query"),
+        ),
+        handler=_tool_search_recipes,
+        read_only=True,
+        idempotent=True,
+    ),
+    "get_recipe": Tool(
+        title="Get recipe",
+        description="Get one recipe in full, including its method, ingredients and tags.",
+        schema=_schema({"recipe_id": P_RECIPE}, ("recipe_id",)),
+        handler=_tool_get_recipe,
+        read_only=True,
+        idempotent=True,
+    ),
+    "create_recipe": Tool(
+        title="Create recipe",
+        description=(
+            "Create a recipe in a household. Ingredients may be given as plain names or "
+            "as objects carrying a quantity description and an optional flag; any that "
+            "are new to the household are created. Tags are created on demand too."
+        ),
+        schema=_schema(
+            {
+                "household_id": P_HOUSEHOLD,
+                **RECIPE_FIELDS,
                 "items": {
                     "type": "array",
+                    "description": "Ingredients, as names or {name, description, optional} objects.",
                     "items": {
                         "oneOf": [
                             {"type": "string"},
                             {
                                 "type": "object",
                                 "properties": {
-                                    "name": {"type": "string"},
-                                    "description": {"type": "string"},
-                                    "optional": {"type": "boolean"},
+                                    "name": {"type": "string", "description": "Ingredient name."},
+                                    "description": P_QUANTITY,
+                                    "optional": {
+                                        "type": "boolean",
+                                        "description": "True if the recipe works without it.",
+                                    },
                                 },
                                 "required": ["name"],
                             },
                         ]
                     },
                 },
-                "tags": {"type": "array", "items": {"type": "string"}},
+                "tags": {
+                    "type": "array",
+                    "description": "Tag names, e.g. 'vegetarian'. Created if they do not exist.",
+                    "items": {"type": "string"},
+                },
             },
-            "required": ["household_id", "name"],
-        },
-        _tool_create_recipe,
+            ("household_id", "name"),
+        ),
+        handler=_tool_create_recipe,
     ),
-    "get_recipe": (
-        {
-            "type": "object",
-            "properties": {"recipe_id": {"type": "integer"}},
-            "required": ["recipe_id"],
-        },
-        _tool_get_recipe,
+    "update_recipe": Tool(
+        title="Update recipe",
+        description=(
+            "Change fields on an existing recipe. Only the fields you pass are touched, "
+            "and each one replaces the stored value outright. Ingredients and tags are "
+            "managed with the add_recipe_item and add_recipe_tag tools."
+        ),
+        schema=_schema({"recipe_id": P_RECIPE, **RECIPE_FIELDS}, ("recipe_id",)),
+        handler=_tool_update_recipe,
+        destructive=True,
+        idempotent=True,
     ),
-    "delete_recipe": (
-        {
-            "type": "object",
-            "properties": {"recipe_id": {"type": "integer"}},
-            "required": ["recipe_id"],
-        },
-        _tool_delete_recipe,
+    "delete_recipe": Tool(
+        title="Delete recipe",
+        description="Permanently delete a recipe and its ingredient and tag links.",
+        schema=_schema({"recipe_id": P_RECIPE}, ("recipe_id",)),
+        handler=_tool_delete_recipe,
+        destructive=True,
     ),
-    "list_items": (
-        {
-            "type": "object",
-            "properties": {
-                "household_id": {"type": "integer"},
-                "search": {"type": "string"},
+    "add_recipe_item": Tool(
+        title="Add ingredient to recipe",
+        description=(
+            "Add an ingredient to a recipe, creating the item in the household if "
+            "needed. Calling it for an ingredient already on the recipe updates that "
+            "ingredient's quantity and optional flag instead of duplicating it."
+        ),
+        schema=_schema(
+            {
+                "recipe_id": P_RECIPE,
+                "name": {"type": "string", "description": "Ingredient name, e.g. 'plain flour'."},
+                "description": P_QUANTITY,
+                "optional": {"type": "boolean", "description": "True if the recipe works without it."},
             },
-            "required": ["household_id"],
-        },
-        _tool_list_items,
+            ("recipe_id", "name"),
+        ),
+        handler=_tool_add_recipe_item,
+        idempotent=True,
     ),
-    "list_tags": (
-        {
-            "type": "object",
-            "properties": {"household_id": {"type": "integer"}},
-            "required": ["household_id"],
-        },
-        _tool_list_tags,
-    ),
-    "create_tag": (
-        {
-            "type": "object",
-            "properties": {
-                "household_id": {"type": "integer"},
-                "name": {"type": "string"},
+    "remove_recipe_item": Tool(
+        title="Remove ingredient from recipe",
+        description="Remove an ingredient from a recipe. The item itself is kept in the household.",
+        schema=_schema(
+            {
+                "recipe_id": P_RECIPE,
+                "item_id": {"type": "integer", "description": "Item id, from the recipe's items."},
             },
-            "required": ["household_id", "name"],
-        },
-        _tool_create_tag,
+            ("recipe_id", "item_id"),
+        ),
+        handler=_tool_remove_recipe_item,
+        destructive=True,
+        idempotent=True,
     ),
-    "create_shoppinglist": (
-        {
-            "type": "object",
-            "properties": {
-                "household_id": {"type": "integer"},
-                "name": {"type": "string"},
+    "list_tags": Tool(
+        title="List tags",
+        description="List a household's recipe tags, e.g. 'vegetarian' or 'quick'.",
+        schema=_schema(_paged({"household_id": P_HOUSEHOLD}), ("household_id",)),
+        handler=_tool_list_tags,
+        read_only=True,
+        idempotent=True,
+    ),
+    "create_tag": Tool(
+        title="Create tag",
+        description=(
+            "Create a recipe tag in a household. Returns the existing tag if one with "
+            "that name is already there."
+        ),
+        schema=_schema(
+            {
+                "household_id": P_HOUSEHOLD,
+                "name": {"type": "string", "description": "Tag name, e.g. 'vegetarian'."},
             },
-            "required": ["household_id", "name"],
-        },
-        _tool_create_shoppinglist,
+            ("household_id", "name"),
+        ),
+        handler=_tool_create_tag,
+        idempotent=True,
     ),
-    "delete_shoppinglist": (
-        {
-            "type": "object",
-            "properties": {"list_id": {"type": "integer"}},
-            "required": ["list_id"],
-        },
-        _tool_delete_shoppinglist,
-    ),
-    "remove_item_from_list": (
-        {
-            "type": "object",
-            "properties": {
-                "list_id": {"type": "integer"},
-                "item_id": {"type": "integer"},
-                "name": {"type": "string"},
+    "add_recipe_tag": Tool(
+        title="Tag a recipe",
+        description="Attach a tag to a recipe, creating the tag in the household if needed.",
+        schema=_schema(
+            {
+                "recipe_id": P_RECIPE,
+                "name": {"type": "string", "description": "Tag name to attach."},
             },
-            "required": ["list_id"],
-        },
-        _tool_remove_item_from_list,
+            ("recipe_id", "name"),
+        ),
+        handler=_tool_add_recipe_tag,
+        idempotent=True,
     ),
-    "add_recipe_item": (
-        {
-            "type": "object",
-            "properties": {
-                "recipe_id": {"type": "integer"},
-                "name": {"type": "string"},
-                "description": {"type": "string"},
-                "optional": {"type": "boolean"},
+    "remove_recipe_tag": Tool(
+        title="Untag a recipe",
+        description=(
+            "Detach a tag from a recipe, by tag_id or name. The tag itself stays in the "
+            "household."
+        ),
+        schema=_schema(
+            {
+                "recipe_id": P_RECIPE,
+                "tag_id": {"type": "integer", "description": "Tag id. Preferred over name."},
+                "name": {"type": "string", "description": "Tag name, if the id is unknown."},
             },
-            "required": ["recipe_id", "name"],
-        },
-        _tool_add_recipe_item,
+            ("recipe_id",),
+        ),
+        handler=_tool_remove_recipe_tag,
+        destructive=True,
+        idempotent=True,
     ),
-    "remove_recipe_item": (
-        {
-            "type": "object",
-            "properties": {
-                "recipe_id": {"type": "integer"},
-                "item_id": {"type": "integer"},
+    "list_planner": Tool(
+        title="List meal plan",
+        description="List the recipes planned in a household, with the day each is planned for.",
+        schema=_schema(_paged({"household_id": P_HOUSEHOLD}), ("household_id",)),
+        handler=_tool_list_planner,
+        read_only=True,
+        idempotent=True,
+    ),
+    "add_planner_entry": Tool(
+        title="Plan a meal",
+        description=(
+            "Plan a recipe for a given day. Planning the same recipe on the same day "
+            "twice changes nothing. The recipe must belong to the household."
+        ),
+        schema=_schema(
+            {
+                "household_id": P_HOUSEHOLD,
+                "recipe_id": P_RECIPE,
+                "cooking_date": P_COOKING_DATE,
+                "yields": {"type": "integer", "description": "Servings to cook, default 1."},
             },
-            "required": ["recipe_id", "item_id"],
-        },
-        _tool_remove_recipe_item,
+            ("household_id", "recipe_id", "cooking_date"),
+        ),
+        handler=_tool_add_planner_entry,
+        idempotent=True,
     ),
-    "add_recipe_tag": (
-        {
-            "type": "object",
-            "properties": {
-                "recipe_id": {"type": "integer"},
-                "name": {"type": "string"},
+    "remove_planner_entry": Tool(
+        title="Unplan a meal",
+        description="Remove a planned recipe from a given day. The recipe itself is kept.",
+        schema=_schema(
+            {
+                "household_id": P_HOUSEHOLD,
+                "recipe_id": P_RECIPE,
+                "cooking_date": P_COOKING_DATE,
             },
-            "required": ["recipe_id", "name"],
-        },
-        _tool_add_recipe_tag,
+            ("household_id", "recipe_id", "cooking_date"),
+        ),
+        handler=_tool_remove_planner_entry,
+        destructive=True,
+        idempotent=True,
     ),
-    "remove_recipe_tag": (
-        {
-            "type": "object",
-            "properties": {
-                "recipe_id": {"type": "integer"},
-                "tag_id": {"type": "integer"},
-                "name": {"type": "string"},
+    "list_expenses": Tool(
+        title="List expenses",
+        description="List a household's expenses, most recent first, with who paid and the split.",
+        schema=_schema(
+            _paged(
+                {
+                    "household_id": P_HOUSEHOLD,
+                    "search": {
+                        "type": "string",
+                        "description": "Case-insensitive substring filter on the expense name.",
+                    },
+                }
+            ),
+            ("household_id",),
+        ),
+        handler=_tool_list_expenses,
+        read_only=True,
+        idempotent=True,
+    ),
+    "create_expense": Tool(
+        title="Record expense",
+        description=(
+            "Record an expense paid by you, in the household's currency. Defaults to now "
+            "unless a date is given."
+        ),
+        schema=_schema(
+            {
+                "household_id": P_HOUSEHOLD,
+                "name": {"type": "string", "description": "What the money was spent on."},
+                "amount": {"type": "number", "description": "Amount paid, in the household currency."},
+                "description": {"type": "string", "description": "Optional longer note."},
+                "date": {"type": "string", "description": "When it was paid, ISO-8601. Defaults to now."},
             },
-            "required": ["recipe_id"],
-        },
-        _tool_remove_recipe_tag,
+            ("household_id", "name", "amount"),
+        ),
+        handler=_tool_create_expense,
     ),
-    "update_recipe": (
-        {
-            "type": "object",
-            "properties": {
-                "recipe_id": {"type": "integer"},
-                "name": {"type": "string"},
-                "description": {"type": "string"},
-                "time": {"type": "integer"},
-                "cook_time": {"type": "integer"},
-                "prep_time": {"type": "integer"},
-                "yields": {"type": "integer"},
-                "source": {"type": "string"},
-                "visibility": {"type": "integer", "enum": [0, 1, 2]},
+    "delete_expense": Tool(
+        title="Delete expense",
+        description="Permanently delete an expense and rebalance the household accordingly.",
+        schema=_schema(
+            {"expense_id": {"type": "integer", "description": "Expense id, from list_expenses."}},
+            ("expense_id",),
+        ),
+        handler=_tool_delete_expense,
+        destructive=True,
+    ),
+    "scrape_recipe": Tool(
+        title="Import recipe from a URL",
+        description=(
+            "Fetch a recipe from a web page and return it parsed. Nothing is saved, so "
+            "keeping it is a separate step. Fails on sites that publish no "
+            "recognisable recipe data."
+        ),
+        schema=_schema(
+            {
+                "household_id": P_HOUSEHOLD,
+                "url": {"type": "string", "description": "Public URL of the recipe page."},
             },
-            "required": ["recipe_id"],
-        },
-        _tool_update_recipe,
-    ),
-    "list_expenses": (
-        {
-            "type": "object",
-            "properties": {
-                "household_id": {"type": "integer"},
-                "search": {"type": "string"},
-            },
-            "required": ["household_id"],
-        },
-        _tool_list_expenses,
-    ),
-    "create_expense": (
-        {
-            "type": "object",
-            "properties": {
-                "household_id": {"type": "integer"},
-                "name": {"type": "string"},
-                "amount": {"type": "number"},
-                "description": {"type": "string"},
-                "date": {"type": "string"},
-            },
-            "required": ["household_id", "name", "amount"],
-        },
-        _tool_create_expense,
-    ),
-    "delete_expense": (
-        {
-            "type": "object",
-            "properties": {"expense_id": {"type": "integer"}},
-            "required": ["expense_id"],
-        },
-        _tool_delete_expense,
-    ),
-    "list_planner": (
-        {
-            "type": "object",
-            "properties": {"household_id": {"type": "integer"}},
-            "required": ["household_id"],
-        },
-        _tool_list_planner,
-    ),
-    "add_planner_entry": (
-        {
-            "type": "object",
-            "properties": {
-                "household_id": {"type": "integer"},
-                "recipe_id": {"type": "integer"},
-                "cooking_date": {"type": "string"},
-                "yields": {"type": "integer"},
-            },
-            "required": ["household_id", "recipe_id", "cooking_date"],
-        },
-        _tool_add_planner_entry,
-    ),
-    "remove_planner_entry": (
-        {
-            "type": "object",
-            "properties": {
-                "household_id": {"type": "integer"},
-                "recipe_id": {"type": "integer"},
-                "cooking_date": {"type": "string"},
-            },
-            "required": ["household_id", "recipe_id", "cooking_date"],
-        },
-        _tool_remove_planner_entry,
-    ),
-    "scrape_recipe": (
-        {
-            "type": "object",
-            "properties": {
-                "household_id": {"type": "integer"},
-                "url": {"type": "string"},
-            },
-            "required": ["household_id", "url"],
-        },
-        _tool_scrape_recipe,
+            ("household_id", "url"),
+        ),
+        handler=_tool_scrape_recipe,
+        read_only=True,
+        open_world=True,
     ),
 }
 
@@ -889,10 +1141,11 @@ def _dispatch(body: Any) -> Any:
                 "tools": [
                     {
                         "name": name,
-                        "description": f"KitchenOwl tool: {name}",
-                        "inputSchema": schema,
+                        "description": tool.description,
+                        "inputSchema": tool.schema,
+                        "annotations": tool.annotations(),
                     }
-                    for name, (schema, _) in TOOLS.items()
+                    for name, tool in TOOLS.items()
                 ]
             }
         elif method == "tools/call":
@@ -902,9 +1155,14 @@ def _dispatch(body: Any) -> Any:
                 return None if is_notification else _rpc_error(
                     id_value, -32602, f"Unknown tool: {name}"
                 )
-            _, handler = TOOLS[name]
-            result = _as_tool_result(handler(args))
-            db.session.commit()
+            try:
+                result = _as_tool_result(TOOLS[name].handler(args))
+                db.session.commit()
+            except Exception as e:
+                # A tool that fails is a result the model can react to, not a
+                # protocol fault that should abort the call.
+                db.session.rollback()
+                result = _as_tool_error(_tool_error_message(e))
         else:
             return None if is_notification else _rpc_error(
                 id_value, -32601, f"Method not found: {method}"

--- a/backend/app/controller/mcp_controller.py
+++ b/backend/app/controller/mcp_controller.py
@@ -1,12 +1,13 @@
 from __future__ import annotations
 
 import json
-import time
 import uuid
+from dataclasses import dataclass, field
 from datetime import datetime
+from queue import Empty, Queue
 from typing import Any, Callable
 
-from flask import Blueprint, Response, jsonify, request, stream_with_context
+from flask import Blueprint, Response, jsonify, request, url_for
 from flask_jwt_extended import current_user, jwt_required
 
 from app import db
@@ -30,14 +31,6 @@ from app.models.recipe import RecipeVisibility
 from app.service.recipe_scraping import scrape
 
 mcp = Blueprint("mcp", __name__)
-
-
-def _jsonrpc_ok(id_value: Any, result: Any):
-    return jsonify({"jsonrpc": "2.0", "id": id_value, "result": result})
-
-
-def _jsonrpc_err(id_value: Any, code: int, message: str):
-    return jsonify({"jsonrpc": "2.0", "id": id_value, "error": {"code": code, "message": message}})
 
 
 def _as_tool_result(payload: Any):
@@ -839,86 +832,179 @@ TOOLS: dict[str, tuple[dict[str, Any], Callable[[dict[str, Any]], Any]]] = {
 }
 
 
-def _handle_jsonrpc(body: dict[str, Any]):
+SUPPORTED_PROTOCOL_VERSIONS = ("2025-06-18", "2025-03-26", "2024-11-05")
+LATEST_PROTOCOL_VERSION = SUPPORTED_PROTOCOL_VERSIONS[0]
+
+SERVER_INSTRUCTIONS = (
+    "KitchenOwl manages households, each of which owns shopping lists, items, "
+    "recipes, tags, meal plans and expenses. Nearly every tool is scoped to a "
+    "household, so call list_households first and reuse the id you get back."
+)
+
+SSE_KEEPALIVE_SECONDS = 15
+
+
+def _dispatch(body: Any) -> Any:
+    # Returns the response to send back, or None for notifications, which the
+    # protocol requires be left unanswered.
+    if isinstance(body, list):
+        responses = [r for r in (_dispatch(item) for item in body) if r is not None]
+        return responses or None
+
+    if not isinstance(body, dict):
+        return {
+            "jsonrpc": "2.0",
+            "id": None,
+            "error": {"code": -32600, "message": "Invalid Request"},
+        }
+
     id_value = body.get("id")
     method = body.get("method")
     params = body.get("params") or {}
+    is_notification = "id" not in body
 
     try:
         if method == "initialize":
-            return _jsonrpc_ok(
-                id_value,
-                {
-                    "protocolVersion": "2024-11-05",
-                    "capabilities": {"tools": {}},
-                    "serverInfo": {"name": "kitchenowl-mcp", "version": str(BACKEND_VERSION)},
-                },
+            requested = params.get("protocolVersion")
+            version = (
+                requested
+                if requested in SUPPORTED_PROTOCOL_VERSIONS
+                else LATEST_PROTOCOL_VERSION
             )
-
-        if method == "notifications/initialized":
-            return ("", 204)
-
-        if method == "ping":
-            return _jsonrpc_ok(id_value, {})
-
-        if method == "tools/list":
-            tools = []
-            for name, (schema, _) in TOOLS.items():
-                tools.append(
+            result = {
+                "protocolVersion": version,
+                "capabilities": {"tools": {"listChanged": False}},
+                "serverInfo": {
+                    "name": "kitchenowl-mcp",
+                    "version": str(BACKEND_VERSION),
+                },
+                "instructions": SERVER_INSTRUCTIONS,
+            }
+        elif method is not None and method.startswith("notifications/"):
+            return None
+        elif method == "ping":
+            result = {}
+        elif method == "tools/list":
+            result = {
+                "tools": [
                     {
                         "name": name,
                         "description": f"KitchenOwl tool: {name}",
                         "inputSchema": schema,
                     }
-                )
-            return _jsonrpc_ok(id_value, {"tools": tools})
-
-        if method == "tools/call":
+                    for name, (schema, _) in TOOLS.items()
+                ]
+            }
+        elif method == "tools/call":
             name = params.get("name")
             args = params.get("arguments") or {}
             if name not in TOOLS:
-                return _jsonrpc_err(id_value, -32601, f"Unknown tool: {name}")
+                return None if is_notification else _rpc_error(
+                    id_value, -32602, f"Unknown tool: {name}"
+                )
             _, handler = TOOLS[name]
-            result = handler(args)
+            result = _as_tool_result(handler(args))
             db.session.commit()
-            return _jsonrpc_ok(id_value, _as_tool_result(result))
-
-        return _jsonrpc_err(id_value, -32601, f"Method not found: {method}")
+        else:
+            return None if is_notification else _rpc_error(
+                id_value, -32601, f"Method not found: {method}"
+            )
     except Exception as e:
         db.session.rollback()
-        return _jsonrpc_err(id_value, -32000, str(e))
+        return None if is_notification else _rpc_error(id_value, -32000, str(e))
+
+    return None if is_notification else {"jsonrpc": "2.0", "id": id_value, "result": result}
 
 
-@mcp.route("", methods=["GET"])
-@mcp.route("/sse", methods=["GET"])
-@jwt_required()
-def mcp_sse():
-    session_id = str(uuid.uuid4())
+def _rpc_error(id_value: Any, code: int, message: str) -> dict[str, Any]:
+    return {"jsonrpc": "2.0", "id": id_value, "error": {"code": code, "message": message}}
 
-    def generate():
-        endpoint = request.url_root.rstrip("/") + f"/mcp/messages/{session_id}"
-        yield f"event: endpoint\ndata: {endpoint}\n\n"
-        while True:
-            yield "event: ping\ndata: {}\n\n"
-            time.sleep(15)
 
-    return Response(
-        stream_with_context(generate()),
-        mimetype="text/event-stream",
-        headers={"Cache-Control": "no-cache", "X-Accel-Buffering": "no"},
-    )
+# Streamable HTTP. Stateless: no session id is issued, so this transport keeps
+# working across multiple uWSGI workers.
 
 
 @mcp.route("", methods=["POST"])
 @jwt_required()
 def mcp_post():
-    body = request.get_json(silent=True) or {}
-    return _handle_jsonrpc(body)
+    response = _dispatch(request.get_json(silent=True))
+    if response is None:
+        return "", 202
+    return jsonify(response)
+
+
+@mcp.route("", methods=["GET", "DELETE"])
+@jwt_required()
+def mcp_stream_unsupported():
+    # Nothing to push outside a request and no session to tear down; the spec
+    # allows 405 for both.
+    return Response(status=405, headers={"Allow": "POST"})
+
+
+# HTTP+SSE. Both halves of a session must be served by the same process, so this
+# registry is deliberately per-worker.
+
+
+@dataclass
+class _SseSession:
+    user_id: int
+    id: str = field(default_factory=lambda: str(uuid.uuid4()))
+    outbox: Queue = field(default_factory=Queue)
+
+
+_sse_sessions: dict[str, _SseSession] = {}
+
+
+@mcp.route("/sse", methods=["GET"])
+@jwt_required()
+def mcp_sse():
+    session = _SseSession(user_id=current_user.id)
+    _sse_sessions[session.id] = session
+
+    # Relative, so it survives a reverse proxy that request.url_root would not.
+    endpoint = f"{url_for('mcp.mcp_messages')}?session_id={session.id}"
+
+    def generate():
+        try:
+            yield f"event: endpoint\ndata: {endpoint}\n\n"
+            while True:
+                try:
+                    message = session.outbox.get(timeout=SSE_KEEPALIVE_SECONDS)
+                except Empty:
+                    yield ": keep-alive\n\n"
+                    continue
+                yield "event: message\ndata: {}\n\n".format(
+                    json.dumps(message, ensure_ascii=False, default=str)
+                )
+        finally:
+            _sse_sessions.pop(session.id, None)
+
+    return Response(
+        generate(),
+        mimetype="text/event-stream",
+        headers={
+            "Cache-Control": "no-cache, no-transform",
+            "Connection": "keep-alive",
+            "X-Accel-Buffering": "no",
+        },
+    )
 
 
 @mcp.route("/messages", methods=["POST"])
 @mcp.route("/messages/<session_id>", methods=["POST"])
 @jwt_required()
 def mcp_messages(session_id: str | None = None):
-    body = request.get_json(silent=True) or {}
-    return _handle_jsonrpc(body)
+    session_id = session_id or request.args.get("session_id")
+    session = _sse_sessions.get(session_id) if session_id else None
+
+    if session is None:
+        return jsonify({"error": "Unknown or expired session"}), 404
+    if session.user_id != current_user.id:
+        return jsonify({"error": "Session belongs to a different user"}), 403
+
+    response = _dispatch(request.get_json(silent=True))
+    if response is not None:
+        session.outbox.put(response)
+
+    # The reply travels over the SSE stream, not this response.
+    return "", 202

--- a/backend/tests/api/test_api_mcp.py
+++ b/backend/tests/api/test_api_mcp.py
@@ -64,6 +64,8 @@ def test_mcp_scrape_recipe_tool_unsupported(user_client_with_household, househol
 
     assert res.status_code == 200
     body = res.get_json()
-    assert 'error' in body
-    assert body['error']['code'] == -32000
-    assert 'Unsupported website' in body['error']['message']
+    # A tool that fails reports isError so the model can react, rather than
+    # raising a protocol-level error that aborts the call.
+    assert 'error' not in body
+    assert body['result']['isError'] is True
+    assert 'Unsupported website' in body['result']['content'][0]['text']

--- a/backend/tests/api/test_api_mcp_tools.py
+++ b/backend/tests/api/test_api_mcp_tools.py
@@ -1,0 +1,189 @@
+import pytest
+
+from app.controller.mcp_controller import MAX_PAGE_SIZE, TOOLS
+
+
+@pytest.fixture
+def list_id(user_client_with_household, household_id):
+    response = user_client_with_household.get(f"/api/household/{household_id}/shoppinglist")
+    assert response.status_code == 200
+    return response.get_json()[0]["id"]
+
+
+def _rpc(client, method, params=None, id_=1):
+    payload = {"jsonrpc": "2.0", "id": id_, "method": method}
+    if params is not None:
+        payload["params"] = params
+    return client.post("/mcp", json=payload)
+
+
+def _call(client, name, arguments):
+    return _rpc(client, "tools/call", {"name": name, "arguments": arguments})
+
+
+def _structured(res):
+    body = res.get_json()
+    assert "error" not in body, body
+    assert not body["result"].get("isError"), body["result"]
+    return body["result"]["structuredContent"]
+
+
+def _tools_by_name(client):
+    body = _rpc(client, "tools/list", {}).get_json()
+    return {t["name"]: t for t in body["result"]["tools"]}
+
+
+def test_every_tool_is_properly_described(user_client_with_household):
+    tools = _tools_by_name(user_client_with_household)
+    assert set(tools) == set(TOOLS)
+
+    for name, tool in tools.items():
+        description = tool["description"]
+        assert not description.startswith("KitchenOwl tool:"), name
+        assert len(description) > 40, f"{name} description is too thin"
+        assert description.strip().endswith("."), name
+
+        annotations = tool["annotations"]
+        assert annotations["title"], name
+        for hint in ("readOnlyHint", "destructiveHint", "idempotentHint", "openWorldHint"):
+            assert isinstance(annotations[hint], bool), f"{name}.{hint}"
+        if annotations["readOnlyHint"]:
+            assert not annotations["destructiveHint"], f"{name} is both read-only and destructive"
+
+
+def test_every_declared_parameter_is_described(user_client_with_household):
+    for name, tool in _tools_by_name(user_client_with_household).items():
+        schema = tool["inputSchema"]
+        assert schema["type"] == "object", name
+        for param, spec in schema["properties"].items():
+            assert spec.get("description"), f"{name}.{param} has no description"
+        for required in schema["required"]:
+            assert required in schema["properties"], f"{name}.{required}"
+
+
+def test_only_the_internet_facing_tool_is_open_world(user_client_with_household):
+    tools = _tools_by_name(user_client_with_household)
+    open_world = {n for n, t in tools.items() if t["annotations"]["openWorldHint"]}
+    assert open_world == {"scrape_recipe"}
+
+
+def test_list_tools_report_paging_metadata(user_client_with_household, household_id):
+    result = _structured(
+        _call(user_client_with_household, "list_recipes", {"household_id": household_id})
+    )
+    assert result["items"] == []
+    assert result["total"] == 0
+    assert result["offset"] == 0
+    assert result["has_more"] is False
+
+
+def test_paging_walks_a_result_set(user_client_with_household, household_id, list_id):
+    for i in range(5):
+        _call(
+            user_client_with_household,
+            "add_item_by_name",
+            {"list_id": list_id, "name": f"item{i}"},
+        )
+
+    first = _structured(
+        _call(
+            user_client_with_household,
+            "list_shoppinglist_items",
+            {"list_id": list_id, "limit": 2},
+        )
+    )
+    assert len(first["items"]) == 2
+    assert first["total"] == 5
+    assert first["has_more"] is True
+
+    last = _structured(
+        _call(
+            user_client_with_household,
+            "list_shoppinglist_items",
+            {"list_id": list_id, "limit": 2, "offset": 4},
+        )
+    )
+    assert len(last["items"]) == 1
+    assert last["has_more"] is False
+
+
+def test_page_size_is_capped(user_client_with_household, household_id):
+    # An oversized limit must be clamped rather than honoured or rejected.
+    result = _structured(
+        _call(
+            user_client_with_household,
+            "list_items",
+            {"household_id": household_id, "limit": MAX_PAGE_SIZE * 10},
+        )
+    )
+    assert len(result["items"]) <= MAX_PAGE_SIZE
+
+
+def test_recipe_lists_return_summaries_not_full_bodies(
+    user_client_with_household, household_id
+):
+    created = _structured(
+        _call(
+            user_client_with_household,
+            "create_recipe",
+            {
+                "household_id": household_id,
+                "name": "Dal",
+                "description": "A very long method " * 50,
+                "items": ["red lentils"],
+                "tags": ["vegetarian"],
+            },
+        )
+    )
+
+    listed = _structured(
+        _call(user_client_with_household, "list_recipes", {"household_id": household_id})
+    )
+    summary = listed["items"][0]
+    assert summary["name"] == "Dal"
+    assert summary["tags"] == ["vegetarian"]
+    # The bulky fields belong to get_recipe, not the listing.
+    assert "description" not in summary
+    assert "items" not in summary
+    assert "household" not in summary
+
+    full = _structured(
+        _call(user_client_with_household, "get_recipe", {"recipe_id": created["id"]})
+    )
+    assert full["description"]
+    assert [i["name"] for i in full["items"]] == ["red lentils"]
+
+
+def test_missing_required_argument_is_a_tool_error(user_client_with_household):
+    body = _call(user_client_with_household, "list_recipes", {}).get_json()
+    assert "error" not in body
+    assert body["result"]["isError"] is True
+    assert "household_id" in body["result"]["content"][0]["text"]
+
+
+def test_unknown_tool_is_a_protocol_error(user_client_with_household):
+    body = _call(user_client_with_household, "no_such_tool", {}).get_json()
+    assert body["error"]["code"] == -32602
+
+
+def test_cross_household_access_is_denied(user_client_with_household):
+    body = _call(
+        user_client_with_household, "list_recipes", {"household_id": 999999}
+    ).get_json()
+    assert body["result"]["isError"] is True
+
+
+def test_internal_errors_do_not_leak_details(user_client_with_household, household_id):
+    from unittest.mock import patch
+
+    with patch(
+        "app.controller.mcp_controller._paginate_query",
+        side_effect=RuntimeError("secret db internals"),
+    ):
+        body = _call(
+            user_client_with_household, "list_recipes", {"household_id": household_id}
+        ).get_json()
+
+    text = body["result"]["content"][0]["text"]
+    assert body["result"]["isError"] is True
+    assert "secret db internals" not in text

--- a/backend/tests/api/test_api_mcp_transport.py
+++ b/backend/tests/api/test_api_mcp_transport.py
@@ -1,0 +1,186 @@
+import json
+
+import pytest
+
+from app.controller.mcp_controller import (
+    LATEST_PROTOCOL_VERSION,
+    SUPPORTED_PROTOCOL_VERSIONS,
+    _SseSession,
+    _sse_sessions,
+)
+
+
+def _rpc(client, method, params=None, id_=1):
+    payload = {"jsonrpc": "2.0", "id": id_, "method": method}
+    if params is not None:
+        payload["params"] = params
+    return client.post("/mcp", json=payload)
+
+
+def _read_sse_events(response, count):
+    # Pulls `count` (event, data) pairs off a streamed response, skipping
+    # keep-alive comments.
+    events = []
+    buffer = ""
+    for chunk in response.response:
+        buffer += chunk.decode()
+        while "\n\n" in buffer:
+            raw, buffer = buffer.split("\n\n", 1)
+            event, data = None, None
+            for line in raw.splitlines():
+                if line.startswith("event:"):
+                    event = line[len("event:"):].strip()
+                elif line.startswith("data:"):
+                    data = line[len("data:"):].strip()
+            if event is not None:
+                events.append((event, data))
+            if len(events) >= count:
+                return events
+    return events
+
+
+def test_initialize_echoes_supported_protocol_version(user_client_with_household):
+    for version in SUPPORTED_PROTOCOL_VERSIONS:
+        res = _rpc(user_client_with_household, "initialize", {"protocolVersion": version})
+        assert res.status_code == 200
+        assert res.get_json()["result"]["protocolVersion"] == version
+
+
+def test_initialize_falls_back_to_latest_for_unknown_version(user_client_with_household):
+    res = _rpc(user_client_with_household, "initialize", {"protocolVersion": "1999-01-01"})
+    assert res.get_json()["result"]["protocolVersion"] == LATEST_PROTOCOL_VERSION
+
+
+def test_initialize_reports_server_info_and_instructions(user_client_with_household):
+    result = _rpc(user_client_with_household, "initialize", {}).get_json()["result"]
+    assert result["serverInfo"]["name"] == "kitchenowl-mcp"
+    assert result["capabilities"]["tools"] is not None
+    assert result["instructions"]
+
+
+def test_notifications_get_202_and_no_body(user_client_with_household):
+    res = user_client_with_household.post(
+        "/mcp", json={"jsonrpc": "2.0", "method": "notifications/initialized"}
+    )
+    assert res.status_code == 202
+    assert res.data == b""
+
+
+def test_ping_roundtrip(user_client_with_household):
+    body = _rpc(user_client_with_household, "ping").get_json()
+    assert body["result"] == {}
+    assert body["id"] == 1
+
+
+def test_unknown_method_is_a_protocol_error(user_client_with_household):
+    body = _rpc(user_client_with_household, "does/not/exist").get_json()
+    assert body["error"]["code"] == -32601
+
+
+def test_batch_request_returns_one_response_per_request(user_client_with_household):
+    res = user_client_with_household.post(
+        "/mcp",
+        json=[
+            {"jsonrpc": "2.0", "id": 1, "method": "ping"},
+            {"jsonrpc": "2.0", "method": "notifications/initialized"},
+            {"jsonrpc": "2.0", "id": 2, "method": "ping"},
+        ],
+    )
+    body = res.get_json()
+    assert isinstance(body, list)
+    # The notification must not produce a response.
+    assert [r["id"] for r in body] == [1, 2]
+
+
+def test_malformed_body_is_an_invalid_request(user_client_with_household):
+    body = user_client_with_household.post("/mcp", json="not-an-object").get_json()
+    assert body["error"]["code"] == -32600
+
+
+def test_get_and_delete_on_root_are_405(user_client_with_household):
+    for method in ("get", "delete"):
+        res = getattr(user_client_with_household, method)("/mcp")
+        assert res.status_code == 405
+        assert res.headers["Allow"] == "POST"
+
+
+def test_transport_requires_authentication(client):
+    res = client.post("/mcp", json={"jsonrpc": "2.0", "id": 1, "method": "ping"})
+    assert res.status_code == 401
+
+
+@pytest.fixture
+def sse_session(user_client_with_household):
+    _sse_sessions.clear()
+    res = user_client_with_household.get("/mcp/sse")
+    assert res.status_code == 200
+    assert res.mimetype == "text/event-stream"
+
+    (event, data), = _read_sse_events(res, 1)
+    assert event == "endpoint"
+
+    yield data, data.split("session_id=")[1], res
+    res.close()
+    _sse_sessions.clear()
+
+
+def test_sse_announces_a_relative_endpoint(sse_session):
+    endpoint, session_id, _ = sse_session
+    assert endpoint.startswith("/mcp/messages?session_id=")
+    assert session_id in _sse_sessions
+
+
+def test_sse_post_is_accepted_and_reply_arrives_on_the_stream(
+    sse_session, user_client_with_household
+):
+    endpoint, _, stream = sse_session
+
+    res = user_client_with_household.post(
+        endpoint, json={"jsonrpc": "2.0", "id": 7, "method": "ping"}
+    )
+    assert res.status_code == 202
+    assert res.data == b""
+
+    (event, data), = _read_sse_events(stream, 1)
+    assert event == "message"
+    assert json.loads(data) == {"jsonrpc": "2.0", "id": 7, "result": {}}
+
+
+def test_sse_notification_produces_no_stream_message(
+    sse_session, user_client_with_household
+):
+    endpoint, session_id, _ = sse_session
+
+    res = user_client_with_household.post(
+        endpoint, json={"jsonrpc": "2.0", "method": "notifications/initialized"}
+    )
+    assert res.status_code == 202
+    assert _sse_sessions[session_id].outbox.empty()
+
+
+def test_post_to_unknown_session_is_404(user_client_with_household):
+    res = user_client_with_household.post(
+        "/mcp/messages?session_id=nope", json={"jsonrpc": "2.0", "id": 1, "method": "ping"}
+    )
+    assert res.status_code == 404
+
+
+def test_post_without_session_id_is_404(user_client_with_household):
+    res = user_client_with_household.post(
+        "/mcp/messages", json={"jsonrpc": "2.0", "id": 1, "method": "ping"}
+    )
+    assert res.status_code == 404
+
+
+def test_cannot_push_into_another_users_session(user_client_with_household):
+    _sse_sessions.clear()
+    foreign = _SseSession(user_id=99999)
+    _sse_sessions[foreign.id] = foreign
+
+    res = user_client_with_household.post(
+        f"/mcp/messages?session_id={foreign.id}",
+        json={"jsonrpc": "2.0", "id": 1, "method": "ping"},
+    )
+    assert res.status_code == 403
+    assert foreign.outbox.empty()
+    _sse_sessions.clear()


### PR DESCRIPTION
Builds on #1121. This is a cross-fork PR so I can't set that as the base, and the diff below includes it. The commit to review here is the second one, `feat(mcp): Describe and annotate tools, bound list responses`.

Every tool is advertised as `KitchenOwl tool: <name>` with no parameter descriptions, so a model has to infer what things do from the name alone. Tools now carry a written description, a title, per-parameter descriptions, and readOnly/destructive/idempotent/openWorld annotations.

`list_recipes` returned `obj_to_full_dict()` for every recipe in the household, method body and nested household included, with no limit. It now returns summaries, and every list tool takes limit/offset and reports total and has_more. Page size is capped at 200.

Tool failures come back as `isError` results rather than JSON-RPC protocol errors, which is what the spec asks for and lets the model recover. Unexpected exceptions are logged and replaced with a generic message rather than returning `str(e)`.

There is more behind this. Each link shows only that branch's own changes:

| Branch | Change | |
|---|---|---|
| [socket events](https://github.com/jmylchreest/kitchenowl/compare/feat/mcp-tool-metadata...fix/mcp-socket-events) | +127/-1 | MCP writes don't emit the socket events the REST endpoints do, so open apps show a stale list |
| [workflow tools](https://github.com/jmylchreest/kitchenowl/compare/fix/mcp-socket-events...feat/mcp-workflow-tools) | +385/-12 | `add_recipe_items_to_list`, bulk add, categories |
| [token scopes](https://github.com/jmylchreest/kitchenowl/compare/21c04352...feat/mcp-token-scopes) | +327/-51 | read/write/full scopes on long-lived tokens, optionally pinned to one household |
| [attribution](https://github.com/jmylchreest/kitchenowl/compare/feat/mcp-token-scopes...feat/mcp-agent-attribution) | +180/-18 | record which token added an item |
| [item reuse](https://github.com/jmylchreest/kitchenowl/compare/feat/mcp-agent-attribution...feat/mcp-item-reuse) | +200/-53 | report when a tool invents a new household item instead of reusing one |
| [suggestions](https://github.com/jmylchreest/kitchenowl/compare/feat/mcp-item-reuse...feat/mcp-suggestions) | +226 | expose the existing nightly recipe ranking |
| [planner history](https://github.com/jmylchreest/kitchenowl/compare/feat/mcp-suggestions...fix/mcp-planner-history) | +131 | planner changes via MCP don't write `RecipeHistory`, so they never feed suggestions |
| [docs](https://github.com/jmylchreest/kitchenowl/compare/fix/mcp-planner-history...docs/mcp-server) | +121 | documentation, closes #901 |

How would you like me to submit the subsequent PRs, if at all you'd like me to?