### PR TITLE
feat: option to default to NLP for english recipes

### DIFF
--- a/backend/app/service/ingredient_parsing.py
+++ b/backend/app/service/ingredient_parsing.py
@@ -4,11 +4,13 @@ import ingredient_parser.dataclasses
 from litellm import completion
 import json
 import os
+import re
 
 from app.config import SUPPORTED_LANGUAGES
 
 LLM_MODEL = os.getenv("LLM_MODEL")
 LLM_API_URL = os.getenv("LLM_API_URL")
+NLP_IF_EN = os.getenv("NLP_IF_EN")
 
 
 class IngredientParsingResult:
@@ -109,10 +111,14 @@ Return only JSON and nothing else.
 def parseIngredients(
     ingredients: list[str],
     targetLanguageCode=None,
+    sourceLanguageCode=None,
 ) -> list[IngredientParsingResult]:
+    en_pattern = r"^en"
+    
     if LLM_MODEL:
-        try:
-            return parseLLM(ingredients, targetLanguageCode) or parseNLP(ingredients)
-        except Exception as e:
-            print("Error parsing ingredients:", e)
+        if not NLP_IF_EN and not re.match(sourceLanguageCode, en_pattern):
+            try:
+                return parseLLM(ingredients, targetLanguageCode) or parseNLP(ingredients)
+            except Exception as e:
+                print("Error parsing ingredients:", e)
     return parseNLP(ingredients)

--- a/backend/app/service/recipe_scraping.py
+++ b/backend/app/service/recipe_scraping.py
@@ -109,7 +109,9 @@ def scrapePublic(url: str, html: str, household: Household) -> dict[str, Any] | 
     recipe.photo = scraper.image()
     recipe.source = url
     items = {}
-    for ingredient in parseIngredients(scraper.ingredients(), household.language):
+    # Relies on site meta data to detect language. Possible mismatch if there is a spanish recipe on a english website
+    sourceLanguageCode = scraper.language() or "" # Fallback to handle None cases and default to LLM if in use
+    for ingredient in parseIngredients(scraper.ingredients(), household.language, sourceLanguageCode):
         name = ingredient.name if ingredient.name else ingredient.originalText or ""
         item = Item.find_name_starts_with(household.id, name)
         if item:


### PR DESCRIPTION
Added the env variable NLP_IF_EN to default to NLP for ingredient parsing even if an LLM is available because I want the option to use the LLM only in the cases where it is necessary.
As mentioned in the comments, this does not guarantee finding the correct language because the scrapers language parsing uses website metadata and not the recipe text to determine the language, but it should match for most cases. If no language metadata is found, the default case is to use the LLM.