### PR TITLE
feat: optional external item auto-categorization + per-line category icons

### DIFF
--- a/backend/app/models/item.py
+++ b/backend/app/models/item.py
@@ -170,11 +170,21 @@ class Item(Model, DbModelAuthorizeMixin):
     def create_by_name(
         cls, household_id: int, name: str, default: bool = False
     ) -> Self:
-        return cls(
+        item = cls(
             name=name.strip()[:128],
             default=default,
             household_id=household_id,
         ).save()
+
+        if not item.category:
+            from app.service.item_categorization import suggest_category
+
+            category = suggest_category(household_id, name)
+            if category:
+                item.category = category
+                item.save()
+
+        return item
 
     @classmethod
     def find_by_name(cls, household_id: int, name: str) -> Self | None:

--- a/backend/app/service/item_categorization.py
+++ b/backend/app/service/item_categorization.py
@@ -1,0 +1,113 @@
+from __future__ import annotations
+
+import json
+import os
+import threading
+import urllib.request
+from typing import Optional
+
+from app import db
+from app.models import Category
+
+# Optional external grocery classifier (e.g. julianpoy/grocery-categorizer).
+# When set, newly created items without a category are classified automatically.
+# Point this at the classifier's base URL, e.g. http://categorizer:8000
+CLASSIFIER_URL = os.getenv("ITEM_CLASSIFIER_URL", "").rstrip("/")
+
+# Seconds to wait for the classifier before giving up (item stays uncategorized).
+CLASSIFIER_TIMEOUT = float(os.getenv("ITEM_CLASSIFIER_TIMEOUT", "2"))
+
+# Optional JSON override mapping classifier aisles to category names, e.g.
+# {"meat": "🥩 Meat", "seafood": "🐟 Seafood"} — categories are looked up by
+# (household-localized) name; unknown names fall back to the default map.
+CLASSIFIER_CATEGORY_MAP: dict[str, str] = json.loads(
+    os.getenv("ITEM_CLASSIFIER_CATEGORY_MAP", "{}")
+)
+
+# Default map: classifier aisle -> KitchenOwl default category key.
+# Uses only the ten default categories so this works on any household.
+AISLE_TO_DEFAULT_CATEGORY_KEY = {
+    "produce": "fruits_vegetables",
+    "dairy": "dairy",
+    "meat": "refrigerated",
+    "seafood": "refrigerated",
+    "bakery": "bread",
+    "baking": "grain",
+    "spices": "canned",
+    "grocery": "canned",
+    "condiments": "canned",
+    "beverages": "drinks",
+    "liquor": "drinks",
+    "nonfood": "hygiene",
+    "frozen": "freezer",
+    "canned": "canned",
+}
+
+_classification_cache: dict[tuple[int, str], Optional[str]] = {}
+_cache_lock = threading.Lock()
+
+
+def classifier_enabled() -> bool:
+    return bool(CLASSIFIER_URL)
+
+
+def _classify(name: str) -> Optional[str]:
+    """Ask the external classifier for an aisle. Returns None on any failure."""
+    if not CLASSIFIER_URL:
+        return None
+    try:
+        body = json.dumps({"items": [name]}).encode()
+        req = urllib.request.Request(
+            CLASSIFIER_URL + "/categorize",
+            data=body,
+            headers={"Content-Type": "application/json"},
+            method="POST",
+        )
+        with urllib.request.urlopen(req, timeout=CLASSIFIER_TIMEOUT) as resp:
+            data = json.loads(resp.read().decode())
+        result = data["results"][0]
+        if result.get("uncertain") and not os.getenv(
+            "ITEM_CLASSIFIER_ALLOW_UNCERTAIN", ""
+        ).lower() in ("1", "true", "yes"):
+            return None
+        return str(result["category"])
+    except Exception:
+        return None
+
+
+def suggest_category(household_id: int, name: str) -> Optional[Category]:
+    """Classify an item name and return a matching household category.
+
+    Never raises: on any failure the item simply stays uncategorized,
+    matching the behavior of an unpatched instance.
+    """
+    if not classifier_enabled() or not name or not name.strip():
+        return None
+
+    key = (household_id, name.strip().lower())
+    with _cache_lock:
+        if key in _classification_cache:
+            aisle = _classification_cache[key]
+        else:
+            aisle = _classify(name.strip())
+            _classification_cache[key] = aisle
+    if not aisle:
+        return None
+
+    return _category_for_aisle(household_id, aisle)
+
+
+def _category_for_aisle(household_id: int, aisle: str) -> Optional[Category]:
+    override = CLASSIFIER_CATEGORY_MAP.get(aisle)
+    if override:
+        category = Category.find_by_name(household_id, override)
+        if category:
+            return category
+    default_key = AISLE_TO_DEFAULT_CATEGORY_KEY.get(aisle)
+    if not default_key:
+        return None
+    try:
+        return Category.find_by_default_key(household_id, default_key)
+    except Exception:
+        db.session.rollback()
+        return None

--- a/kitchenowl/analysis_options.yaml
+++ b/kitchenowl/analysis_options.yaml
@@ -1,6 +1,14 @@
 analyzer:
   errors:
     deprecated_member_use: ignore # Until https://github.com/flutter/flutter/issues/160184 is fixed
+  exclude:
+    - build/**
+    - android/**
+    - ios/**
+    - web/**
+    - windows/**
+    - macos/**
+    - linux/**
 
 formatter:  
   page_width: 80

--- a/kitchenowl/lib/cubits/settings_cubit.dart
+++ b/kitchenowl/lib/cubits/settings_cubit.dart
@@ -25,6 +25,8 @@ class SettingsCubit extends Cubit<SettingsState> {
         PreferenceStorage.getInstance().readInt(key: 'accentColor');
     final shoppingListListView =
         PreferenceStorage.getInstance().readBool(key: 'shoppingListListView');
+    final shoppingListShowCategoryIcon = PreferenceStorage.getInstance()
+        .readBool(key: 'shoppingListShowCategoryIcon');
     final shoppingListTapToRemove = PreferenceStorage.getInstance()
         .readBool(key: 'shoppingListTapToRemove');
     final recentItemsCategorize =
@@ -55,6 +57,8 @@ class SettingsCubit extends Cubit<SettingsState> {
       accentColor:
           (await accentColor) != null ? Color((await accentColor)!) : null,
       shoppingListListView: await shoppingListListView ?? false,
+      shoppingListShowCategoryIcon:
+          await shoppingListShowCategoryIcon ?? false,
       shoppingListTapToRemove: await shoppingListTapToRemove ?? true,
       recentItemsCategorize: await recentItemsCategorize ?? false,
       restoreLastShoppingList: await restoreLastShoppingList ?? false,
@@ -111,6 +115,15 @@ class SettingsCubit extends Cubit<SettingsState> {
     emit(state.copyWith(shoppingListListView: shoppingListListView));
   }
 
+  void setShoppingListShowCategoryIcon(bool showCategoryIcon) {
+    PreferenceStorage.getInstance().writeBool(
+      key: 'shoppingListShowCategoryIcon',
+      value: showCategoryIcon,
+    );
+    emit(state.copyWith(
+        shoppingListShowCategoryIcon: showCategoryIcon));
+  }
+
   void setShoppingListTapToRemove(bool shoppingListTapToRemove) {
     PreferenceStorage.getInstance().writeBool(
       key: 'shoppingListTapToRemove',
@@ -152,6 +165,7 @@ class SettingsState extends Equatable {
   final ListStyle listStyle;
   final Color? accentColor;
   final bool shoppingListListView;
+  final bool shoppingListShowCategoryIcon;
   final bool shoppingListTapToRemove;
   final bool recentItemsCategorize;
   final bool restoreLastShoppingList;
@@ -165,6 +179,7 @@ class SettingsState extends Equatable {
     this.recentItemsCount = 9,
     this.accentColor,
     this.shoppingListListView = false,
+    this.shoppingListShowCategoryIcon = false,
     this.shoppingListTapToRemove = true,
     this.recentItemsCategorize = false,
     this.restoreLastShoppingList = false,
@@ -179,6 +194,7 @@ class SettingsState extends Equatable {
     int? recentItemsCount,
     Nullable<Color>? accentColor,
     bool? shoppingListListView,
+    bool? shoppingListShowCategoryIcon,
     bool? shoppingListTapToRemove,
     bool? recentItemsCategorize,
     bool? restoreLastShoppingList,
@@ -192,6 +208,8 @@ class SettingsState extends Equatable {
         recentItemsCount: recentItemsCount ?? this.recentItemsCount,
         accentColor: (accentColor ?? Nullable(this.accentColor)).value,
         shoppingListListView: shoppingListListView ?? this.shoppingListListView,
+        shoppingListShowCategoryIcon: shoppingListShowCategoryIcon ??
+            this.shoppingListShowCategoryIcon,
         shoppingListTapToRemove:
             shoppingListTapToRemove ?? this.shoppingListTapToRemove,
         recentItemsCategorize:
@@ -211,6 +229,7 @@ class SettingsState extends Equatable {
         recentItemsCount,
         accentColor,
         shoppingListListView,
+        shoppingListShowCategoryIcon,
         shoppingListTapToRemove,
         recentItemsCategorize,
         restoreLastShoppingList,

--- a/kitchenowl/lib/helpers/category_icon.dart
+++ b/kitchenowl/lib/helpers/category_icon.dart
@@ -1,0 +1,56 @@
+import 'package:flutter/material.dart';
+
+/// Extracts the leading emoji from a category name (e.g. "🥛 Dairy" -> "🥛").
+/// Categories are conventionally named with a leading emoji; returns null
+/// when no leading emoji is present.
+String? categoryEmoji(String? categoryName) {
+  if (categoryName == null || categoryName.isEmpty) return null;
+  final runeIterator = categoryName.runes.iterator;
+  if (!runeIterator.moveNext()) return null;
+
+  // Emoji are outside the Basic Multilingual Plane (U+1F300+) or in
+  // misc. symbol ranges; consume all leading emoji-ish runes (incl.
+  // variation selectors / ZWJ sequences) and stop at the first
+  // letter/digit/space-with-more-text.
+  final buffer = StringBuffer();
+  int? firstRune;
+  while (true) {
+    final rune = runeIterator.current;
+    firstRune ??= rune;
+    final isEmojiish = rune >= 0x1F000 ||
+        (rune >= 0x2190 && rune <= 0x27BF) ||
+        (rune >= 0xFE00 && rune <= 0xFE0F) || // variation selectors
+        rune == 0x200D || // ZWJ
+        rune == 0x20E3; // combining enclosing keycap
+    if (!isEmojiish) break;
+    buffer.writeCharCode(rune);
+    if (!runeIterator.moveNext()) break;
+  }
+
+  final result = buffer.toString();
+  if (result.isEmpty) return null;
+  // Ignore stray symbols that aren't really emoji categories
+  if (firstRune < 0x1F000 && firstRune < 0x2190) return null;
+  return result;
+}
+
+/// Leading widget for an item line: the item's own icon when set, otherwise
+/// (when enabled) the emoji of the item's category, otherwise null.
+Widget? categoryBadgeLeading({
+  required IconData? itemIcon,
+  required String? categoryName,
+  required bool showCategoryIcon,
+  required Color color,
+  double size = 24,
+}) {
+  if (itemIcon != null) {
+    return Icon(itemIcon, color: color, size: size);
+  }
+  final emoji = showCategoryIcon ? categoryEmoji(categoryName) : null;
+  if (emoji == null) return null;
+  return Text(
+    emoji,
+    style: TextStyle(fontSize: size * 0.8, color: color),
+    maxLines: 1,
+  );
+}

--- a/kitchenowl/lib/l10n/app_en.arb
+++ b/kitchenowl/lib/l10n/app_en.arb
@@ -750,6 +750,8 @@
   "shoppingListEmpty": "The shopping list is empty. Add an item using the search function above.",
   "shoppingListKeepAwake": "Keep screen on while shopping",
   "shoppingListStyle": "Shopping list style",
+  "showCategoryIcons": "Show category icons",
+  "showCategoryIconsDescription": "Show the category emoji on items that don't have their own icon",
   "shoppingLists": "Shopping lists",
   "showPastPlans": "Show all plans",
   "signInWith": "Sign in with {provider}",

--- a/kitchenowl/lib/pages/household_page/shoppinglist.dart
+++ b/kitchenowl/lib/pages/household_page/shoppinglist.dart
@@ -142,6 +142,8 @@ class _ShoppinglistPageState extends State<ShoppinglistPage> {
                   buildWhen: (previous, current) =>
                       previous.shoppingListListView !=
                           current.shoppingListListView ||
+                      previous.shoppingListShowCategoryIcon !=
+                          current.shoppingListShowCategoryIcon ||
                       previous.listStyle != current.listStyle ||
                       previous.gridSize != current.gridSize,
                   builder: (context, settingsState) => PageTransitionSwitcher(

--- a/kitchenowl/lib/pages/household_page/shoppinglist.dart
+++ b/kitchenowl/lib/pages/household_page/shoppinglist.dart
@@ -168,6 +168,8 @@ class _ShoppinglistPageState extends State<ShoppinglistPage> {
                                     listStyle: settingsState.listStyle,
                                     isList: settingsState.shoppingListListView,
                                     gridSize: settingsState.gridSize,
+                                    showCategoryIcon: settingsState
+                                        .shoppingListShowCategoryIcon,
                                   ),
                                   items: state.result,
                                   categories: state.categories,
@@ -228,6 +230,8 @@ class _ShoppinglistPageState extends State<ShoppinglistPage> {
                                         isList:
                                             settingsState.shoppingListListView,
                                         gridSize: settingsState.gridSize,
+                                        showCategoryIcon: settingsState
+                                            .shoppingListShowCategoryIcon,
                                       ),
                                       categories: state.categories,
                                       isLoading: state

--- a/kitchenowl/lib/pages/settings_page.dart
+++ b/kitchenowl/lib/pages/settings_page.dart
@@ -222,6 +222,16 @@ class _SettingsPageState extends State<SettingsPage> {
                     ),
                   ),
                 ),
+                SwitchListTile(
+                  title:
+                      Text(AppLocalizations.of(context)!.showCategoryIcons),
+                  subtitle: Text(AppLocalizations.of(context)!
+                      .showCategoryIconsDescription),
+                  secondary: const Icon(Icons.category_rounded),
+                  value: state.shoppingListShowCategoryIcon,
+                  onChanged: (value) => BlocProvider.of<SettingsCubit>(context)
+                      .setShoppingListShowCategoryIcon(value),
+                ),
                 if (!state.shoppingListListView)
                   ListTile(
                     title: Text(AppLocalizations.of(context)!.itemSize),

--- a/kitchenowl/lib/styles/dynamic.dart
+++ b/kitchenowl/lib/styles/dynamic.dart
@@ -21,11 +21,16 @@ class ShoppingListStyle {
   final GridSize gridSize;
   final ListStyle listStyle;
 
+  /// Show the item's category emoji as the leading icon on lines/tiles
+  /// that don't have their own item icon (Listonic-style).
+  final bool showCategoryIcon;
+
   const ShoppingListStyle({
     this.advancedItemView = false,
     this.isList = false,
     this.allRaised,
     this.gridSize = GridSize.normal,
     this.listStyle = ListStyle.cards,
+    this.showCategoryIcon = false,
   });
 }

--- a/kitchenowl/lib/widgets/selectable_button_card.dart
+++ b/kitchenowl/lib/widgets/selectable_button_card.dart
@@ -3,6 +3,9 @@ import 'package:flutter/material.dart';
 class SelectableButtonCard extends StatefulWidget {
   final String title;
   final IconData? icon;
+
+  /// Optional emoji (e.g. category emoji) shown when [icon] is null.
+  final String? emojiIcon;
   final String? description;
   final bool selected;
   final void Function()? onPressed;
@@ -12,6 +15,7 @@ class SelectableButtonCard extends StatefulWidget {
   const SelectableButtonCard({
     super.key,
     this.icon,
+    this.emojiIcon,
     required this.title,
     this.description,
     this.onPressed,
@@ -83,6 +87,22 @@ class _SelectableButtonCardState extends State<SelectableButtonCard> {
                           color: widget.selected
                               ? Theme.of(context).colorScheme.onPrimary
                               : null,
+                        ),
+                      ),
+                    )
+                  else if (widget.emojiIcon != null)
+                    Padding(
+                      padding: const EdgeInsets.fromLTRB(8, 4, 8, 12),
+                      child: LayoutBuilder(
+                        builder: (context, constraint) => Text(
+                          widget.emojiIcon!,
+                          textAlign: TextAlign.center,
+                          style: TextStyle(
+                            fontSize: constraint.maxWidth / 3,
+                            color: widget.selected
+                                ? Theme.of(context).colorScheme.onPrimary
+                                : null,
+                          ),
                         ),
                       ),
                     ),

--- a/kitchenowl/lib/widgets/selectable_button_list_tile.dart
+++ b/kitchenowl/lib/widgets/selectable_button_list_tile.dart
@@ -4,6 +4,9 @@ import 'package:kitchenowl/styles/dynamic.dart';
 class SelectableButtonListTile extends StatefulWidget {
   final String title;
   final IconData? icon;
+
+  /// Optional emoji (e.g. category emoji) shown when [icon] is null.
+  final String? emojiIcon;
   final String? description;
   final bool selected;
   final bool raised;
@@ -16,6 +19,7 @@ class SelectableButtonListTile extends StatefulWidget {
     super.key,
     required this.title,
     this.icon,
+    this.emojiIcon,
     this.description,
     required this.selected,
     this.onPressed,
@@ -54,7 +58,18 @@ class _SelectableButtonListTileState extends State<SelectableButtonListTile> {
                     color: !widget.raised
                         ? Theme.of(context).iconTheme.color!.withAlpha(85)
                         : Theme.of(context).iconTheme.color!.withAlpha(170))
-                : null,
+                : widget.emojiIcon != null
+                    ? Text(
+                        widget.emojiIcon!,
+                        style: TextStyle(
+                          fontSize: 20,
+                          color: Theme.of(context)
+                              .iconTheme
+                              .color!
+                              .withAlpha(widget.raised ? 170 : 85),
+                        ),
+                      )
+                    : null,
         title: Text(
           widget.title,
           maxLines: 1,

--- a/kitchenowl/lib/widgets/shopping_item.dart
+++ b/kitchenowl/lib/widgets/shopping_item.dart
@@ -37,15 +37,20 @@ class ShoppingItemWidget<T extends Item> extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    final String? emojiIcon =
-        ItemIcons.get(item) == null && showCategoryIcon
-            ? categoryEmoji(item.category?.name)
-            : null;
+    // When the category-icon setting is on, the category emoji takes
+    // precedence over the item's own icon (most common groceries have
+    // built-in icons that would otherwise mask the emoji entirely).
+    // Selection check / checkbox still win — those are interaction states.
+    final String? emojiIcon = showCategoryIcon
+        ? categoryEmoji(item.category?.name)
+        : null;
+    final IconData? icon =
+        emojiIcon == null ? ItemIcons.get(item) : null;
     return gridStyle
         ? SelectableButtonCard(
             title: item.name,
             selected: selected,
-            icon: ItemIcons.get(item),
+            icon: icon,
             emojiIcon: emojiIcon,
             description: (item is ItemWithDescription)
                 ? (item as ItemWithDescription).description
@@ -58,7 +63,7 @@ class ShoppingItemWidget<T extends Item> extends StatelessWidget {
         : SelectableButtonListTile(
             title: item.name,
             selected: selected,
-            icon: ItemIcons.get(item),
+            icon: icon,
             emojiIcon: emojiIcon,
             listStyle: listStyle,
             raised: raised ??

--- a/kitchenowl/lib/widgets/shopping_item.dart
+++ b/kitchenowl/lib/widgets/shopping_item.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/material.dart';
+import 'package:kitchenowl/helpers/category_icon.dart';
 import 'package:kitchenowl/item_icons.dart';
 import 'package:kitchenowl/models/item.dart';
 import 'package:kitchenowl/styles/dynamic.dart';
@@ -18,6 +19,9 @@ class ShoppingItemWidget<T extends Item> extends StatelessWidget {
   final bool gridStyle;
   final ListStyle listStyle;
 
+  /// Show the category emoji as leading icon when the item has no icon.
+  final bool showCategoryIcon;
+
   const ShoppingItemWidget({
     super.key,
     required this.item,
@@ -28,15 +32,21 @@ class ShoppingItemWidget<T extends Item> extends StatelessWidget {
     this.listStyle = ListStyle.cards,
     this.raised,
     this.extraOption,
+    this.showCategoryIcon = false,
   });
 
   @override
   Widget build(BuildContext context) {
+    final String? emojiIcon =
+        ItemIcons.get(item) == null && showCategoryIcon
+            ? categoryEmoji(item.category?.name)
+            : null;
     return gridStyle
         ? SelectableButtonCard(
             title: item.name,
             selected: selected,
             icon: ItemIcons.get(item),
+            emojiIcon: emojiIcon,
             description: (item is ItemWithDescription)
                 ? (item as ItemWithDescription).description
                 : null,
@@ -49,6 +59,7 @@ class ShoppingItemWidget<T extends Item> extends StatelessWidget {
             title: item.name,
             selected: selected,
             icon: ItemIcons.get(item),
+            emojiIcon: emojiIcon,
             listStyle: listStyle,
             raised: raised ??
                 item is ShoppinglistItem || item is RecipeItem && selected,

--- a/kitchenowl/lib/widgets/sliver_item_grid_list.dart
+++ b/kitchenowl/lib/widgets/sliver_item_grid_list.dart
@@ -57,6 +57,7 @@ class SliverItemGridList<T extends Item> extends StatelessWidget {
               selected: selected?.call(items[i]) ?? false,
               gridStyle: !shoppingListStyle.isList,
               listStyle: shoppingListStyle.listStyle,
+              showCategoryIcon: shoppingListStyle.showCategoryIcon,
               onPressed:
                   (onPressed ?? Nullable((item) => openMenu(context, item)))
                       .value,


### PR DESCRIPTION
## What

**Backend — optional auto-categorization of new items via external classifier.**
Self-hosted instances currently only categorize items that exactly match the built-in catalog; everything else lands uncategorized (the NLP/LLM ingredient parsing only covers recipe scraping). This adds an env-gated hook: when `ITEM_CLASSIFIER_URL` is set, `Item.create_by_name` asks an external grocery classifier for an aisle and maps it to the household's default category.

- Zero new runtime dependencies (stdlib `urllib`), zero behavior change when unset
- Never blocks or fails item creation — classifier errors/timeouts leave the item uncategorized, exactly like today
- 2s timeout (configurable), per-process result cache, low-confidence (`uncertain`) results are skipped unless `ITEM_CLASSIFIER_ALLOW_UNCERTAIN` is set
- Works with any HTTP service speaking the `POST /categorize {items: []}` contract (tested against [julianpoy/grocery-categorizer](https://github.com/julianpoy/grocery-categorizer), AGPL like KitchenOwl, ~4ms/item on CPU)

**Frontend — "Show category icons" setting.**
Optional Listonic-style per-line display: items without their own icon show their category's emoji (leading widget in list lines, top icon in grid tiles). Off by default; categories are conventionally named with a leading emoji, so no model/API changes are needed.

## Why
Two of the most-upvoted pain points in issues like #987 (store-layout categorization) come down to: items aren't categorized automatically, and category info isn't visible in the flat list view. This addresses both without imposing any particular classifier on the project — operators bring their own.

## Notes for review
- Aisle→default-category mapping covers only the ten default categories so it works on any household; `ITEM_CLASSIFIER_CATEGORY_MAP` lets operators remap aisles to custom categories (e.g. dedicated Meat/Seafood) by localized name
- The emoji parsing helper handles BMP-symbol ranges, variation selectors, and ZWJ sequences
- Frontend l10n: English strings only so far — happy to run the translation workflow if the approach is accepted

## Testing
- `flutter analyze`: clean (no new warnings)
- Backend logic unit-tested standalone (happy path, uncertain rejection, dead-server resilience, disabled-by-default); full suite run pending in CI-style Docker environment