### PR TITLE
feat: optional checkbox mode for shopping list (list view)

### DIFF
--- a/kitchenowl/lib/cubits/settings_cubit.dart
+++ b/kitchenowl/lib/cubits/settings_cubit.dart
@@ -27,6 +27,8 @@ class SettingsCubit extends Cubit<SettingsState> {
         PreferenceStorage.getInstance().readBool(key: 'shoppingListListView');
     final shoppingListTapToRemove = PreferenceStorage.getInstance()
         .readBool(key: 'shoppingListTapToRemove');
+    final shoppingListCheckboxMode = PreferenceStorage.getInstance()
+        .readBool(key: 'shoppingListCheckboxMode');
     final recentItemsCategorize =
         PreferenceStorage.getInstance().readBool(key: 'recentItemsCategorize');
     final restoreLastShoppingList = PreferenceStorage.getInstance()
@@ -56,6 +58,7 @@ class SettingsCubit extends Cubit<SettingsState> {
           (await accentColor) != null ? Color((await accentColor)!) : null,
       shoppingListListView: await shoppingListListView ?? false,
       shoppingListTapToRemove: await shoppingListTapToRemove ?? true,
+      shoppingListCheckboxMode: await shoppingListCheckboxMode ?? false,
       recentItemsCategorize: await recentItemsCategorize ?? false,
       restoreLastShoppingList: await restoreLastShoppingList ?? false,
       shoppingListKeepAwake: await shoppingListKeepAwake ?? false,
@@ -119,6 +122,14 @@ class SettingsCubit extends Cubit<SettingsState> {
     emit(state.copyWith(shoppingListTapToRemove: shoppingListTapToRemove));
   }
 
+  void setShoppingListCheckboxMode(bool shoppingListCheckboxMode) {
+    PreferenceStorage.getInstance().writeBool(
+      key: 'shoppingListCheckboxMode',
+      value: shoppingListCheckboxMode,
+    );
+    emit(state.copyWith(shoppingListCheckboxMode: shoppingListCheckboxMode));
+  }
+
   void setRecentItemsCategorize(bool recentItemsCategorize) {
     PreferenceStorage.getInstance().writeBool(
       key: 'recentItemsCategorize',
@@ -153,6 +164,7 @@ class SettingsState extends Equatable {
   final Color? accentColor;
   final bool shoppingListListView;
   final bool shoppingListTapToRemove;
+  final bool shoppingListCheckboxMode;
   final bool recentItemsCategorize;
   final bool restoreLastShoppingList;
   final bool shoppingListKeepAwake;
@@ -166,6 +178,7 @@ class SettingsState extends Equatable {
     this.accentColor,
     this.shoppingListListView = false,
     this.shoppingListTapToRemove = true,
+    this.shoppingListCheckboxMode = false,
     this.recentItemsCategorize = false,
     this.restoreLastShoppingList = false,
     this.shoppingListKeepAwake = false,
@@ -180,6 +193,7 @@ class SettingsState extends Equatable {
     Nullable<Color>? accentColor,
     bool? shoppingListListView,
     bool? shoppingListTapToRemove,
+    bool? shoppingListCheckboxMode,
     bool? recentItemsCategorize,
     bool? restoreLastShoppingList,
     bool? shoppingListKeepAwake,
@@ -194,6 +208,8 @@ class SettingsState extends Equatable {
         shoppingListListView: shoppingListListView ?? this.shoppingListListView,
         shoppingListTapToRemove:
             shoppingListTapToRemove ?? this.shoppingListTapToRemove,
+        shoppingListCheckboxMode:
+            shoppingListCheckboxMode ?? this.shoppingListCheckboxMode,
         recentItemsCategorize:
             recentItemsCategorize ?? this.recentItemsCategorize,
         restoreLastShoppingList:
@@ -212,6 +228,7 @@ class SettingsState extends Equatable {
         accentColor,
         shoppingListListView,
         shoppingListTapToRemove,
+        shoppingListCheckboxMode,
         recentItemsCategorize,
         restoreLastShoppingList,
         shoppingListKeepAwake,

--- a/kitchenowl/lib/l10n/app_en.arb
+++ b/kitchenowl/lib/l10n/app_en.arb
@@ -399,6 +399,8 @@
   "@setupTitle": {},
   "@share": {},
   "@shoppingList": {},
+  "@shoppingListCheckboxMode": {},
+  "@shoppingListCheckboxModeDescription": {},
   "@shoppingListContainsEntries": {
     "placeholders": {
       "entriesCount": {
@@ -743,6 +745,8 @@
   "setupTitle": "Hey there! Ready to shop?",
   "share": "Share",
   "shoppingList": "Shopping list",
+  "shoppingListCheckboxMode": "Checkboxes in list view",
+  "shoppingListCheckboxModeDescription": "Show a checkbox next to each item. Tapping the checkbox removes the item; tapping the row opens the item details.",
   "shoppingListContainsEntries": "{entriesCount, plural, =0{The shopping list contains no items.} =1{The shopping list contains 1 item.} other{The shopping list contains {entriesCount} items.}}",
   "shoppingListDelete": "Delete shopping list",
   "shoppingListDeleteConfirmation": "Are you sure you want to delete {shoppingList}?",

--- a/kitchenowl/lib/pages/household_page/shoppinglist.dart
+++ b/kitchenowl/lib/pages/household_page/shoppinglist.dart
@@ -142,6 +142,8 @@ class _ShoppinglistPageState extends State<ShoppinglistPage> {
                   buildWhen: (previous, current) =>
                       previous.shoppingListListView !=
                           current.shoppingListListView ||
+                      previous.shoppingListCheckboxMode !=
+                          current.shoppingListCheckboxMode ||
                       previous.listStyle != current.listStyle ||
                       previous.gridSize != current.gridSize,
                   builder: (context, settingsState) => PageTransitionSwitcher(
@@ -236,18 +238,32 @@ class _ShoppinglistPageState extends State<ShoppinglistPage> {
                                           state.selectedListItems,
                                       sorting: state.sorting,
                                       shoppingList: state.selectedShoppinglist,
-                                      onPressed: Nullable((Item item) {
-                                        if (item is ShoppinglistItem) {
-                                          if (App.settings
-                                              .shoppingListTapToRemove) {
-                                            cubit.remove(item);
-                                          } else {
-                                            cubit.selectItem(item);
-                                          }
-                                        } else {
-                                          cubit.add(item);
-                                        }
-                                      }),
+                                      // In checkbox mode the row tap opens the
+                                      // item page (the default fallback in
+                                      // SliverItemGridList when onPressed is
+                                      // null) and the leading checkbox removes
+                                      // the item.
+                                      onPressed:
+                                          (App.settings.shoppingListListView &&
+                                                  App.settings
+                                                      .shoppingListCheckboxMode)
+                                              ? null
+                                              : Nullable((Item item) {
+                                                  if (item
+                                                      is ShoppinglistItem) {
+                                                    if (App
+                                                        .settings
+                                                        .shoppingListTapToRemove) {
+                                                      cubit.remove(item);
+                                                    } else {
+                                                      cubit.selectItem(item);
+                                                    }
+                                                  } else {
+                                                    cubit.add(item);
+                                                  }
+                                                }),
+                                      onCheckboxPressed:
+                                          Nullable(cubit.remove),
                                       onRecentPressed: Nullable(cubit.add),
                                       onRefresh: cubit.refresh,
                                     ),

--- a/kitchenowl/lib/pages/settings_page.dart
+++ b/kitchenowl/lib/pages/settings_page.dart
@@ -312,6 +312,18 @@ class _SettingsPageState extends State<SettingsPage> {
                     ),
                   ),
                 ),
+                if (state.shoppingListListView)
+                  SwitchListTile(
+                    title:
+                        Text(AppLocalizations.of(context)!.shoppingListCheckboxMode),
+                    subtitle: Text(AppLocalizations.of(context)!
+                        .shoppingListCheckboxModeDescription),
+                    secondary: const Icon(Icons.check_box_outlined),
+                    value: state.shoppingListCheckboxMode,
+                    onChanged: (value) =>
+                        BlocProvider.of<SettingsCubit>(context)
+                            .setShoppingListCheckboxMode(value),
+                  ),
               ]),
             ),
           ),

--- a/kitchenowl/lib/widgets/home_page/sliver_category_item_grid_list.dart
+++ b/kitchenowl/lib/widgets/home_page/sliver_category_item_grid_list.dart
@@ -13,6 +13,10 @@ class SliverCategoryItemGridList<T extends Item> extends StatefulWidget {
   final void Function()? onRefresh;
   final Nullable<void Function(T)>? onPressed;
   final Nullable<void Function(T)>? onLongPressed;
+
+  /// Forwarded to [SliverItemGridList]: when set (and the list style is a
+  /// list), an unchecked checkbox is shown as the leading widget.
+  final Nullable<void Function(T)>? onCheckboxPressed;
   final List<T> items;
   final List<Category>? categories; // forwarded to item page on long press
   final ShoppingList? shoppingList; // forwarded to item page on long press
@@ -29,6 +33,7 @@ class SliverCategoryItemGridList<T extends Item> extends StatefulWidget {
     this.onRefresh,
     this.onPressed,
     this.onLongPressed,
+    this.onCheckboxPressed,
     this.items = const [],
     this.categories,
     this.shoppingList,
@@ -73,6 +78,7 @@ class _SliverCategoryItemGridListState<T extends Item>
           isLoading: widget.isLoading,
           onRefresh: widget.onRefresh,
           onPressed: widget.onPressed,
+          onCheckboxPressed: widget.onCheckboxPressed,
           isSubTitle: true,
           extraOption: widget.extraOption,
           shoppingListStyle: widget.shoppingListStyle,
@@ -83,6 +89,7 @@ class _SliverCategoryItemGridListState<T extends Item>
         onRefresh: widget.onRefresh,
         onPressed: widget.onPressed,
         onLongPressed: widget.onLongPressed,
+        onCheckboxPressed: widget.onCheckboxPressed,
         items: widget.items,
         categories: widget.categories,
         shoppingList: widget.shoppingList,

--- a/kitchenowl/lib/widgets/selectable_button_list_tile.dart
+++ b/kitchenowl/lib/widgets/selectable_button_list_tile.dart
@@ -9,6 +9,11 @@ class SelectableButtonListTile extends StatefulWidget {
   final bool raised;
   final void Function()? onPressed;
   final void Function()? onLongPressed;
+
+  /// When set, an unchecked checkbox is shown as the leading widget and
+  /// tapping it invokes this callback (e.g. to remove the item from the
+  /// shopping list).
+  final void Function()? onCheckboxPressed;
   final Widget? extraOption;
   final ListStyle listStyle;
 
@@ -20,6 +25,7 @@ class SelectableButtonListTile extends StatefulWidget {
     required this.selected,
     this.onPressed,
     this.onLongPressed,
+    this.onCheckboxPressed,
     this.raised = true,
     this.extraOption,
     this.listStyle = ListStyle.cards,
@@ -49,12 +55,17 @@ class _SelectableButtonListTileState extends State<SelectableButtonListTile> {
       child: ListTile(
         leading: widget.selected
             ? const Icon(Icons.check_rounded)
-            : widget.icon != null
-                ? Icon(widget.icon,
-                    color: !widget.raised
-                        ? Theme.of(context).iconTheme.color!.withAlpha(85)
-                        : Theme.of(context).iconTheme.color!.withAlpha(170))
-                : null,
+            : widget.onCheckboxPressed != null
+                ? Checkbox(
+                    value: false,
+                    onChanged: (_) => widget.onCheckboxPressed!(),
+                  )
+                : widget.icon != null
+                    ? Icon(widget.icon,
+                        color: !widget.raised
+                            ? Theme.of(context).iconTheme.color!.withAlpha(85)
+                            : Theme.of(context).iconTheme.color!.withAlpha(170))
+                    : null,
         title: Text(
           widget.title,
           maxLines: 1,

--- a/kitchenowl/lib/widgets/shopping_item.dart
+++ b/kitchenowl/lib/widgets/shopping_item.dart
@@ -9,6 +9,10 @@ class ShoppingItemWidget<T extends Item> extends StatelessWidget {
   final T item;
   final void Function(T)? onPressed;
   final void Function(T)? onLongPressed;
+
+  /// When set (and gridStyle = false), an unchecked checkbox is shown as the
+  /// leading widget; tapping it invokes this callback.
+  final void Function(T)? onCheckboxPressed;
   final bool selected;
   final Widget? extraOption;
 
@@ -23,6 +27,7 @@ class ShoppingItemWidget<T extends Item> extends StatelessWidget {
     required this.item,
     this.onPressed,
     this.onLongPressed,
+    this.onCheckboxPressed,
     this.selected = false,
     this.gridStyle = true,
     this.listStyle = ListStyle.cards,
@@ -58,6 +63,9 @@ class ShoppingItemWidget<T extends Item> extends StatelessWidget {
             onPressed: onPressed != null ? () => onPressed!(item) : null,
             onLongPressed:
                 onLongPressed != null ? () => onLongPressed!(item) : null,
+            onCheckboxPressed: onCheckboxPressed != null
+                ? () => onCheckboxPressed!(item)
+                : null,
             extraOption: extraOption,
           );
   }

--- a/kitchenowl/lib/widgets/shopping_list/sliver_shopinglist_item_view.dart
+++ b/kitchenowl/lib/widgets/shopping_list/sliver_shopinglist_item_view.dart
@@ -12,6 +12,11 @@ class SliverShopinglistItemView extends StatelessWidget {
   final List<Category> categories;
   final void Function()? onRefresh;
   final Nullable<void Function(ShoppinglistItem)>? onPressed;
+
+  /// When set and the list is rendered as a list (not grid), each shopping
+  /// list item row shows a leading checkbox; tapping it invokes this
+  /// callback (typically removing the item from the list).
+  final Nullable<void Function(ShoppinglistItem)>? onCheckboxPressed;
   final Nullable<void Function(ItemWithDescription)>? onRecentPressed;
   final ShoppinglistSorting sorting;
   final bool isLoading;
@@ -24,6 +29,7 @@ class SliverShopinglistItemView extends StatelessWidget {
     required this.categories,
     this.onRefresh,
     this.onPressed,
+    this.onCheckboxPressed,
     this.onRecentPressed,
     required this.sorting,
     required this.isLoading,
@@ -49,6 +55,7 @@ class SliverShopinglistItemView extends StatelessWidget {
         isLoading: isLoading,
         onRefresh: onRefresh,
         onPressed: onPressed,
+        onCheckboxPressed: onCheckboxPressed,
         shoppingListStyle: shoppingListStyle,
       );
     } else {
@@ -75,6 +82,7 @@ class SliverShopinglistItemView extends StatelessWidget {
           isLoading: isLoading,
           onRefresh: onRefresh,
           onPressed: onPressed,
+          onCheckboxPressed: onCheckboxPressed,
           shoppingListStyle: shoppingListStyle,
         ));
       }

--- a/kitchenowl/lib/widgets/sliver_item_grid_list.dart
+++ b/kitchenowl/lib/widgets/sliver_item_grid_list.dart
@@ -16,6 +16,10 @@ class SliverItemGridList<T extends Item> extends StatelessWidget {
   final void Function()? onRefresh;
   final Nullable<void Function(T)>? onPressed;
   final Nullable<void Function(T)>? onLongPressed;
+
+  /// When set (and the list style is a list), an unchecked checkbox is shown
+  /// as the leading widget; tapping it invokes this callback.
+  final Nullable<void Function(T)>? onCheckboxPressed;
   final List<T> items;
   final List<Category>? categories; // forwarded to item page on long press
   final ShoppingList? shoppingList; // forwarded to item page on long press
@@ -29,6 +33,7 @@ class SliverItemGridList<T extends Item> extends StatelessWidget {
     this.onRefresh,
     this.onPressed,
     this.onLongPressed,
+    this.onCheckboxPressed,
     this.items = const [],
     this.categories,
     this.shoppingList,
@@ -64,6 +69,7 @@ class SliverItemGridList<T extends Item> extends StatelessWidget {
               onLongPressed:
                   (onLongPressed ?? Nullable((item) => openMenu(context, item)))
                       .value,
+              onCheckboxPressed: onCheckboxPressed?.value,
               extraOption: extraOption?.call(items[i]),
             ),
     );


### PR DESCRIPTION
## What

Adds an opt-in **Checkboxes in list view** setting (Settings → Shopping list section, only visible when list view is enabled).

- Each shopping list row gets a leading checkbox. **Tap the checkbox → item is removed** (same optimistic remove as tap-to-remove mode).
- **Tap the row → opens the item page**, i.e. exactly what a long-press does today.

## Why

Tap-to-remove makes removing fast but hides item details behind a long-press, which is hard to discover. This mode gives both affordances distinct, visible targets: checkbox to check off, row to inspect.

## Implementation notes

- New `shoppingListCheckboxMode` preference (`SettingsCubit`/`SettingsState`), default `false` — no behavior change unless enabled.
- `SelectableButtonListTile` gains `onCheckboxPressed`; when set, the leading slot renders an unchecked `Checkbox`. Confirm-mode's selected check icon still takes precedence.
- Passed through `ShoppingItemWidget` → `SliverItemGridList` → `SliverCategoryItemGridList` → `SliverShopinglistItemView`; only wired in the shopping list page.
- Row-tap = item page falls back to the *existing* null-`onPressed` fallback in `SliverItemGridList` (the same path a long-press uses), so no duplicated navigation logic.
- Recent items and search results are intentionally unchanged (they're add-flows, not check-off flows).
- Grid view unaffected (tiles have no leading slot).
- l10n: new keys in `app_en.arb` only ( untranslated-key placeholders: en ).

## Testing

- `flutter analyze` — no new issues (2 pre-existing warnings in untouched files)
- `flutter test` — all 16 tests pass