### PR TITLE
Reduce MCP recipe list response size

### DIFF
--- a/backend/app/controller/mcp_controller.py
+++ b/backend/app/controller/mcp_controller.py
@@ -2,10 +2,11 @@ from __future__ import annotations
 
 import json
 import uuid
+from collections.abc import Callable
 from dataclasses import dataclass, field
 from datetime import datetime
 from queue import Empty, Queue
-from typing import Any, Callable
+from typing import Any
 
 from flask import Blueprint, Response, jsonify, request, url_for
 from flask_jwt_extended import current_user, jwt_required
@@ -14,23 +15,62 @@ from app import db
 from app.config import BACKEND_VERSION
 from app.errors import NotFoundRequest
 from app.models import (
+    Expense,
+    File,
     History,
     Household,
     HouseholdMember,
     Item,
+    Planner,
     Recipe,
     RecipeItems,
     RecipeTags,
     Shoppinglist,
     ShoppinglistItems,
-    Expense,
-    Planner,
     Tag,
 )
-from app.models.recipe import RecipeVisibility
+from app.models.recipe import (
+    RecipeVisibility,
+    is_within_next_7_days,
+    transform_cooking_date_to_day,
+)
 from app.service.recipe_scraping import scrape
 
 mcp = Blueprint("mcp", __name__)
+
+RECIPE_ADDITIONAL_FIELDS = (
+    "description",
+    "photo",
+    "photo_hash",
+    "time",
+    "cook_time",
+    "prep_time",
+    "yields",
+    "source",
+    "visibility",
+    "created_at",
+    "updated_at",
+    "planned",
+    "planned_days",
+    "planned_cooking_dates",
+    "items",
+    "tags",
+)
+RECIPE_DISCOVERY_ARGUMENTS = {
+    "offset": {"type": "integer", "minimum": 0, "default": 0},
+    "limit": {
+        "type": "integer",
+        "minimum": 1,
+        "maximum": 100,
+        "default": 50,
+    },
+    "additional_fields": {
+        "type": "array",
+        "items": {"type": "string", "enum": list(RECIPE_ADDITIONAL_FIELDS)},
+        "uniqueItems": True,
+        "default": [],
+    },
+}
 
 
 def _as_tool_result(payload: Any):
@@ -98,11 +138,164 @@ def _tool_add_item_by_name(args: dict[str, Any]) -> Any:
     return item.obj_to_dict()
 
 
+def _recipe_discovery_page(query, args: dict[str, Any]) -> dict[str, Any]:
+    offset = int(args.get("offset", 0))
+    limit = int(args.get("limit", 50))
+    if offset < 0:
+        raise ValueError("offset must be non-negative")
+    if limit < 1 or limit > 100:
+        raise ValueError("limit must be between 1 and 100")
+
+    raw_additional_fields = args.get("additional_fields", [])
+    if not isinstance(raw_additional_fields, list) or not all(
+        isinstance(field, str) for field in raw_additional_fields
+    ):
+        raise ValueError("additional_fields must be an array of strings")
+    additional_fields = list(raw_additional_fields)
+    if len(additional_fields) != len(set(additional_fields)):
+        raise ValueError("additional_fields must not contain duplicates")
+    unsupported_fields = sorted(
+        set(additional_fields).difference(RECIPE_ADDITIONAL_FIELDS)
+    )
+    if unsupported_fields:
+        raise ValueError(
+            "Unsupported additional_fields: " + ", ".join(unsupported_fields)
+        )
+
+    scalar_fields = {
+        "description": Recipe.description,
+        "photo": Recipe.photo,
+        "time": Recipe.time,
+        "cook_time": Recipe.cook_time,
+        "prep_time": Recipe.prep_time,
+        "yields": Recipe.yields,
+        "source": Recipe.source,
+        "visibility": Recipe.visibility,
+        "created_at": Recipe.created_at,
+        "updated_at": Recipe.updated_at,
+    }
+    total = query.count()
+    columns = [Recipe.id, Recipe.name]
+    columns.extend(
+        scalar_fields[field]
+        for field in additional_fields
+        if field in scalar_fields
+    )
+    rows = (
+        query.with_entities(*columns)
+        .order_by(Recipe.name, Recipe.id)
+        .offset(offset)
+        .limit(limit)
+        .all()
+    )
+    items = [dict(row._mapping) for row in rows]
+    items_by_id = {item["id"]: item for item in items}
+
+    if "photo_hash" in additional_fields:
+        for item in items:
+            item["photo_hash"] = None
+        if items_by_id:
+            photo_hashes = (
+                db.session.query(Recipe.id, File.blur_hash)
+                .outerjoin(File, Recipe.photo == File.filename)
+                .filter(Recipe.id.in_(items_by_id))
+                .all()
+            )
+            for recipe_id, photo_hash in photo_hashes:
+                items_by_id[recipe_id]["photo_hash"] = photo_hash
+
+    planning_fields = {
+        "planned",
+        "planned_days",
+        "planned_cooking_dates",
+    }
+    requested_planning_fields = planning_fields.intersection(additional_fields)
+    if requested_planning_fields:
+        for item in items:
+            if "planned" in requested_planning_fields:
+                item["planned"] = False
+            if "planned_days" in requested_planning_fields:
+                item["planned_days"] = []
+            if "planned_cooking_dates" in requested_planning_fields:
+                item["planned_cooking_dates"] = []
+        if items_by_id:
+            plans = (
+                db.session.query(Planner.recipe_id, Planner.cooking_date)
+                .filter(Planner.recipe_id.in_(items_by_id))
+                .order_by(Planner.recipe_id, Planner.cooking_date)
+                .all()
+            )
+            for recipe_id, cooking_date in plans:
+                item = items_by_id[recipe_id]
+                if "planned" in requested_planning_fields:
+                    item["planned"] = True
+                if cooking_date <= datetime.min.replace(tzinfo=cooking_date.tzinfo):
+                    continue
+                if "planned_cooking_dates" in requested_planning_fields:
+                    item["planned_cooking_dates"].append(cooking_date)
+                if (
+                    "planned_days" in requested_planning_fields
+                    and is_within_next_7_days(cooking_date)
+                ):
+                    item["planned_days"].append(
+                        transform_cooking_date_to_day(cooking_date)
+                    )
+
+    if "items" in additional_fields:
+        for item in items:
+            item["items"] = []
+        if items_by_id:
+            recipe_items = (
+                db.session.query(
+                    RecipeItems.recipe_id,
+                    Item.id.label("id"),
+                    Item.name.label("name"),
+                    RecipeItems.description.label("description"),
+                    RecipeItems.optional.label("optional"),
+                )
+                .join(RecipeItems.item)
+                .filter(RecipeItems.recipe_id.in_(items_by_id))
+                .order_by(RecipeItems.recipe_id, Item.name, Item.id)
+                .all()
+            )
+            for recipe_item in recipe_items:
+                values = dict(recipe_item._mapping)
+                recipe_id = values.pop("recipe_id")
+                items_by_id[recipe_id]["items"].append(values)
+
+    if "tags" in additional_fields:
+        for item in items:
+            item["tags"] = []
+        if items_by_id:
+            recipe_tags = (
+                db.session.query(
+                    RecipeTags.recipe_id,
+                    Tag.id.label("id"),
+                    Tag.name.label("name"),
+                )
+                .join(RecipeTags.tag)
+                .filter(RecipeTags.recipe_id.in_(items_by_id))
+                .order_by(RecipeTags.recipe_id, Tag.name, Tag.id)
+                .all()
+            )
+            for recipe_tag in recipe_tags:
+                values = dict(recipe_tag._mapping)
+                recipe_id = values.pop("recipe_id")
+                items_by_id[recipe_id]["tags"].append(values)
+
+    returned_until = offset + len(items)
+    return {
+        "items": items,
+        "total": total,
+        "next_offset": returned_until if returned_until < total else None,
+    }
+
+
 def _tool_list_recipes(args: dict[str, Any]) -> Any:
     household_id = int(args["household_id"])
     _require_household_access(household_id)
-    recipes = Recipe.query.filter(Recipe.household_id == household_id).order_by(Recipe.name).all()
-    return {"items": [r.obj_to_full_dict() for r in recipes]}
+    query = Recipe.query.filter(Recipe.household_id == household_id)
+    return _recipe_discovery_page(query, args)
 
 
 def _tool_search_recipes(args: dict[str, Any]) -> Any:
@@ -112,11 +305,8 @@ def _tool_search_recipes(args: dict[str, Any]) -> Any:
     recipes = (
         Recipe.query.filter(Recipe.household_id == household_id)
         .filter(Recipe.name.ilike(f"%{query}%"))
-        .order_by(Recipe.name)
-        .limit(50)
-        .all()
     )
-    return {"items": [r.obj_to_full_dict() for r in recipes]}
+    return _recipe_discovery_page(recipes, args)
 
 
 def _tool_create_recipe(args: dict[str, Any]) -> Any:
@@ -558,7 +748,10 @@ TOOLS: dict[str, tuple[dict[str, Any], Callable[[dict[str, Any]], Any]]] = {
     "list_recipes": (
         {
             "type": "object",
-            "properties": {"household_id": {"type": "integer"}},
+            "properties": {
+                "household_id": {"type": "integer"},
+                **RECIPE_DISCOVERY_ARGUMENTS,
+            },
             "required": ["household_id"],
         },
         _tool_list_recipes,
@@ -569,6 +762,7 @@ TOOLS: dict[str, tuple[dict[str, Any], Callable[[dict[str, Any]], Any]]] = {
             "properties": {
                 "household_id": {"type": "integer"},
                 "query": {"type": "string"},
+                **RECIPE_DISCOVERY_ARGUMENTS,
             },
             "required": ["household_id", "query"],
         },
@@ -831,6 +1025,17 @@ TOOLS: dict[str, tuple[dict[str, Any], Callable[[dict[str, Any]], Any]]] = {
     ),
 }
 
+TOOL_DESCRIPTIONS = {
+    "list_recipes": (
+        "List household recipes as paginated id and name references. Use "
+        "additional_fields for selected bulk data, or get_recipe for one full recipe."
+    ),
+    "search_recipes": (
+        "Search household recipe names and return paginated id and name references. "
+        "Use additional_fields for selected bulk data, or get_recipe for one full recipe."
+    ),
+}
+
 
 SUPPORTED_PROTOCOL_VERSIONS = ("2025-06-18", "2025-03-26", "2024-11-05")
 LATEST_PROTOCOL_VERSION = SUPPORTED_PROTOCOL_VERSIONS[0]
@@ -889,7 +1094,9 @@ def _dispatch(body: Any) -> Any:
                 "tools": [
                     {
                         "name": name,
-                        "description": f"KitchenOwl tool: {name}",
+                        "description": TOOL_DESCRIPTIONS.get(
+                            name, f"KitchenOwl tool: {name}"
+                        ),
                         "inputSchema": schema,
                     }
                     for name, (schema, _) in TOOLS.items()

--- a/backend/tests/api/test_api_mcp.py
+++ b/backend/tests/api/test_api_mcp.py
@@ -1,4 +1,10 @@
+from datetime import UTC, datetime
 from unittest.mock import patch
+
+import pytest
+
+from app import db
+from app.models import File, Item, Recipe, Tag
 
 
 def _rpc(client, method, params=None, id_=1):
@@ -17,6 +23,419 @@ def test_mcp_tools_list_contains_scrape_recipe(user_client_with_household):
     names = {t['name'] for t in tools}
 
     assert 'scrape_recipe' in names
+
+
+def test_mcp_tools_list_describes_recipe_discovery_controls(
+    user_client_with_household,
+):
+    res = _rpc(user_client_with_household, 'tools/list', {})
+    tools = {tool['name']: tool for tool in res.get_json()['result']['tools']}
+    expected_fields = [
+        'description',
+        'photo',
+        'photo_hash',
+        'time',
+        'cook_time',
+        'prep_time',
+        'yields',
+        'source',
+        'visibility',
+        'created_at',
+        'updated_at',
+        'planned',
+        'planned_days',
+        'planned_cooking_dates',
+        'items',
+        'tags',
+    ]
+
+    for tool_name in ('list_recipes', 'search_recipes'):
+        tool = tools[tool_name]
+        properties = tool['inputSchema']['properties']
+        assert properties['offset'] == {
+            'type': 'integer',
+            'minimum': 0,
+            'default': 0,
+        }
+        assert properties['limit'] == {
+            'type': 'integer',
+            'minimum': 1,
+            'maximum': 100,
+            'default': 50,
+        }
+        assert properties['additional_fields'] == {
+            'type': 'array',
+            'items': {'type': 'string', 'enum': expected_fields},
+            'uniqueItems': True,
+            'default': [],
+        }
+        assert 'additional_fields' in tool['description']
+        assert 'get_recipe' in tool['description']
+
+
+def test_mcp_recipe_discovery_classifies_every_recipe_model_field(
+    user_client_with_household,
+):
+    res = _rpc(user_client_with_household, 'tools/list', {})
+    tools = {tool['name']: tool for tool in res.get_json()['result']['tools']}
+    additional_fields = set(
+        tools['list_recipes']['inputSchema']['properties']['additional_fields'][
+            'items'
+        ]['enum']
+    )
+    always_returned_fields = {'id', 'name'}
+    deliberately_excluded_fields = {
+        'household_id',
+        'server_curated',
+        'server_scrapes',
+        'suggestion_score',
+        'suggestion_rank',
+    }
+    computed_and_relationship_fields = {
+        'photo_hash',
+        'planned',
+        'planned_days',
+        'planned_cooking_dates',
+        'items',
+        'tags',
+    }
+    model_fields = set(Recipe.get_column_names())
+
+    unclassified_fields = model_fields.difference(
+        always_returned_fields,
+        deliberately_excluded_fields,
+        additional_fields,
+    )
+    assert not unclassified_fields, (
+        'New Recipe fields must be added to the MCP additional-fields allowlist '
+        f'or deliberately excluded: {sorted(unclassified_fields)}'
+    )
+    assert model_fields == (
+        always_returned_fields
+        | deliberately_excluded_fields
+        | additional_fields.difference(computed_and_relationship_fields)
+    )
+    assert additional_fields.difference(model_fields) == (
+        computed_and_relationship_fields
+    )
+
+
+def test_mcp_list_recipes_returns_compact_references_by_default(
+    user_client_with_household,
+    household_id,
+    recipe_with_items,
+    recipe_name,
+):
+    res = _rpc(
+        user_client_with_household,
+        'tools/call',
+        {
+            'name': 'list_recipes',
+            'arguments': {'household_id': household_id},
+        },
+    )
+
+    assert res.status_code == 200
+    body = res.get_json()
+    assert 'error' not in body
+    assert body['result']['structuredContent'] == {
+        'items': [{'id': recipe_with_items, 'name': recipe_name}],
+        'total': 1,
+        'next_offset': None,
+    }
+
+
+def test_mcp_list_recipes_paginates_with_fifty_item_default(
+    user_client_with_household,
+    household_id,
+):
+    recipes = [
+        Recipe(name=f'Recipe {index:03}', description='', household_id=household_id)
+        for index in range(52)
+    ]
+    db.session.add_all(recipes)
+    db.session.commit()
+
+    first_res = _rpc(
+        user_client_with_household,
+        'tools/call',
+        {
+            'name': 'list_recipes',
+            'arguments': {'household_id': household_id},
+        },
+    )
+    first = first_res.get_json()['result']['structuredContent']
+
+    assert first['total'] == 52
+    assert len(first['items']) == 50
+    assert first['items'][0]['name'] == 'Recipe 000'
+    assert first['items'][-1]['name'] == 'Recipe 049'
+    assert first['next_offset'] == 50
+
+    second_res = _rpc(
+        user_client_with_household,
+        'tools/call',
+        {
+            'name': 'list_recipes',
+            'arguments': {'household_id': household_id, 'offset': 50},
+        },
+    )
+    second = second_res.get_json()['result']['structuredContent']
+
+    assert [item['name'] for item in second['items']] == [
+        'Recipe 050',
+        'Recipe 051',
+    ]
+    assert second['total'] == 52
+    assert second['next_offset'] is None
+
+
+def test_mcp_list_recipes_returns_only_requested_fields(
+    user_client_with_household,
+    household_id,
+    recipe_with_items,
+    recipe_name,
+    recipe_description,
+    recipe_time,
+    recipe_yields,
+    item_name,
+):
+    add_tag_res = _rpc(
+        user_client_with_household,
+        'tools/call',
+        {
+            'name': 'add_recipe_tag',
+            'arguments': {'recipe_id': recipe_with_items, 'name': 'Quick'},
+        },
+    )
+    assert 'error' not in add_tag_res.get_json()
+    item = Item.find_by_name(household_id, item_name)
+    tag = Tag.find_by_name(household_id, 'Quick')
+
+    res = _rpc(
+        user_client_with_household,
+        'tools/call',
+        {
+            'name': 'list_recipes',
+            'arguments': {
+                'household_id': household_id,
+                'additional_fields': [
+                    'description',
+                    'time',
+                    'yields',
+                    'items',
+                    'tags',
+                ],
+            },
+        },
+    )
+
+    assert res.status_code == 200
+    body = res.get_json()
+    assert 'error' not in body
+    assert body['result']['structuredContent']['items'] == [
+        {
+            'id': recipe_with_items,
+            'name': recipe_name,
+            'description': recipe_description,
+            'time': recipe_time,
+            'yields': recipe_yields,
+            'items': [
+                {
+                    'id': item.id,
+                    'name': item_name,
+                    'description': '2 pieces',
+                    'optional': True,
+                }
+            ],
+            'tags': [{'id': tag.id, 'name': 'Quick'}],
+        }
+    ]
+
+
+def test_mcp_list_recipes_supports_all_user_facing_scalar_and_computed_fields(
+    user_client_with_household,
+    household_id,
+    planned_recipe,
+    recipe_name,
+    recipe_description,
+    recipe_time,
+    recipe_yields,
+):
+    recipe = Recipe.find_by_id(planned_recipe)
+    recipe.photo = 'recipe.jpg'
+    recipe.cook_time = 20
+    recipe.prep_time = 10
+    recipe.source = 'https://example.com/recipe'
+    db.session.add(File(filename='recipe.jpg', blur_hash='test-blur-hash'))
+    db.session.add(recipe)
+    db.session.commit()
+
+    additional_fields = [
+        'description',
+        'photo',
+        'photo_hash',
+        'time',
+        'cook_time',
+        'prep_time',
+        'yields',
+        'source',
+        'visibility',
+        'created_at',
+        'updated_at',
+        'planned',
+        'planned_days',
+        'planned_cooking_dates',
+    ]
+    res = _rpc(
+        user_client_with_household,
+        'tools/call',
+        {
+            'name': 'list_recipes',
+            'arguments': {
+                'household_id': household_id,
+                'additional_fields': additional_fields,
+            },
+        },
+    )
+
+    assert res.status_code == 200
+    body = res.get_json()
+    assert 'error' not in body
+    item = body['result']['structuredContent']['items'][0]
+    assert set(item) == {'id', 'name', *additional_fields}
+    assert item | {'created_at': None, 'updated_at': None} == {
+        'id': planned_recipe,
+        'name': recipe_name,
+        'description': recipe_description,
+        'photo': 'recipe.jpg',
+        'photo_hash': 'test-blur-hash',
+        'time': recipe_time,
+        'cook_time': 20,
+        'prep_time': 10,
+        'yields': recipe_yields,
+        'source': 'https://example.com/recipe',
+        'visibility': 0,
+        'created_at': None,
+        'updated_at': None,
+        'planned': True,
+        'planned_days': [
+            datetime.fromtimestamp(
+                pytest.FIX_DATETIME / 1000,
+                UTC,
+            ).weekday()
+        ],
+        'planned_cooking_dates': [pytest.FIX_DATETIME],
+    }
+    assert isinstance(item['created_at'], int)
+    assert isinstance(item['updated_at'], int)
+
+
+def test_mcp_search_recipes_uses_compact_paginated_field_selection(
+    user_client_with_household,
+    household_id,
+):
+    db.session.add_all(
+        [
+            Recipe(name='Alpha soup', description='Alpha instructions', household_id=household_id),
+            Recipe(name='Beta soup', description='Beta instructions', household_id=household_id),
+            Recipe(name='Chocolate cake', description='Cake instructions', household_id=household_id),
+        ]
+    )
+    db.session.commit()
+
+    first_res = _rpc(
+        user_client_with_household,
+        'tools/call',
+        {
+            'name': 'search_recipes',
+            'arguments': {
+                'household_id': household_id,
+                'query': 'soup',
+                'limit': 1,
+                'additional_fields': ['description'],
+            },
+        },
+    )
+    first = first_res.get_json()['result']['structuredContent']
+
+    assert first == {
+        'items': [
+            {
+                'id': 1,
+                'name': 'Alpha soup',
+                'description': 'Alpha instructions',
+            }
+        ],
+        'total': 2,
+        'next_offset': 1,
+    }
+
+    second_res = _rpc(
+        user_client_with_household,
+        'tools/call',
+        {
+            'name': 'search_recipes',
+            'arguments': {
+                'household_id': household_id,
+                'query': 'soup',
+                'offset': 1,
+                'limit': 1,
+            },
+        },
+    )
+    second = second_res.get_json()['result']['structuredContent']
+
+    assert second == {
+        'items': [{'id': 2, 'name': 'Beta soup'}],
+        'total': 2,
+        'next_offset': None,
+    }
+
+
+@pytest.mark.parametrize(
+    ('arguments', 'message'),
+    [
+        ({'offset': -1}, 'offset must be non-negative'),
+        ({'limit': 0}, 'limit must be between 1 and 100'),
+        ({'limit': 101}, 'limit must be between 1 and 100'),
+        (
+            {'additional_fields': 'description'},
+            'additional_fields must be an array of strings',
+        ),
+        (
+            {'additional_fields': ''},
+            'additional_fields must be an array of strings',
+        ),
+        (
+            {'additional_fields': ['description', 'description']},
+            'additional_fields must not contain duplicates',
+        ),
+        (
+            {'additional_fields': ['server_scrapes']},
+            'Unsupported additional_fields: server_scrapes',
+        ),
+    ],
+)
+def test_mcp_recipe_discovery_rejects_invalid_pagination_and_fields(
+    user_client_with_household,
+    household_id,
+    arguments,
+    message,
+):
+    res = _rpc(
+        user_client_with_household,
+        'tools/call',
+        {
+            'name': 'list_recipes',
+            'arguments': {'household_id': household_id} | arguments,
+        },
+    )
+
+    assert res.status_code == 200
+    body = res.get_json()
+    assert body['error']['code'] == -32000
+    assert body['error']['message'] == message
 
 
 def test_mcp_scrape_recipe_tool_success(user_client_with_household, household_id):


### PR DESCRIPTION
This PR reduces the size of MCP responses when listing or searching recipes.

Previously, these tools returned every recipe as a **complete object**. For households with many recipes, this produced very large responses and used a lot of context unnecessarily.

Especially on local LLMs, this could quickly fill the available context window and leave less room for the actual conversation and task. On paid APIs/subscriptions it uses needlessly more tokens/limits, likely causing extra costs, longer inference time or higher limit consumptions.

Recipe results now:
  - Return only the recipe **ID and name** by default
  - Use a default page size of 50 recipes
  - Support pagination with offset and limit
  - Allow callers to request specific data through additional_fields
  - Keep `get_recipe` available when the complete recipe is needed

## Breaking
I am aware this is a breaking API change. However, I think it is fine: LLMs are more adaptive than usual REST/GRPc APIs where the client and server agree on a fixed protocol. Also, the MCP endpoint description is updated to the new functionality, including the names of the additional fields. 

Integrations of the MCP eventually have to be setup again in order to make the updated tool descriptions take effect.

## Tests
Tests cover the entire changes and also **consistency** between the recipe model and the MCP field list.
I also tested the changes manually via Open WebUI and a local model (Qwen 3.8 27B).