### PR TITLE
fix: can't create recipe if image URL is invalid or can't be loaded

### DIFF
--- a/backend/app/service/file_has_access_or_download.py
+++ b/backend/app/service/file_has_access_or_download.py
@@ -42,11 +42,14 @@ def file_has_access_or_download(
         from mimetypes import guess_extension
 
         resp = None
-        if trusted_url:
-            resp = requests.get(newPhoto)
-        else:
-            # Use hardened request manager for untrusted URLs
-            resp = request_manager.send_request("GET", newPhoto)
+        try:
+            if trusted_url:
+                resp = requests.get(newPhoto)
+            else:
+                # Use hardened request manager for untrusted URLs
+                resp = request_manager.send_request("GET", newPhoto)
+        except requests.RequestException:
+            return None
         ext = guess_extension(resp.headers["content-type"])
         if ext and allowed_file("file" + ext):
             filename = secure_filename(str(uuid.uuid4()) + ext)

--- a/backend/app/service/recipe_scraping.py
+++ b/backend/app/service/recipe_scraping.py
@@ -5,6 +5,7 @@ from recipe_scrapers._exceptions import SchemaOrgException
 from recipe_scrapers.__version__ import __version__ as recipe_scrapers_version
 from requests_hardened import Config, Manager
 import requests
+from urllib.parse import urljoin, urlparse
 from app.config import FRONT_URL
 from app.errors import ForbiddenRequest
 from app.models.recipe import RecipeVisibility
@@ -24,6 +25,18 @@ request_manager = Manager(
         user_agent_override=USER_AGENT,
     )
 )
+
+
+def fixRelativeUrl(url: str, baseUrl: str) -> str:
+    """
+    If the URL is already absolute (i.e. includes a scheme and host), returns the unchanged URL.
+    Otherwise, i.e. if the URL is relative, returns an absolute URL of the resource relative to baseUrl.
+    """
+    parsedUrl = urlparse(url)
+    if parsedUrl.hostname:
+        return url
+
+    return urljoin(baseUrl, url)
 
 
 def scrapePublic(url: str, html: str, household: Household) -> dict[str, Any] | None:
@@ -106,7 +119,7 @@ def scrapePublic(url: str, html: str, household: Household) -> dict[str, Any] | 
     ):
         pass
     recipe.description = description
-    recipe.photo = scraper.image()
+    recipe.photo = fixRelativeUrl(scraper.image(), url)
     recipe.source = url
     items = {}
     for ingredient in parseIngredients(scraper.ingredients(), household.language):


### PR DESCRIPTION
Hey, first of all, thanks for working on this app! We've been using it for 3 years now and it's really a lifesaver :)

I noticed that adding recipes fails if the image URL is a relative path. E.g., the `thumbnailUrl` field of https://schema.org/Recipe is just `/example.jpg` instead of a full URL. However, according to https://schema.org/url, URLs may be relative, so this is a bug in KitchenOwl that it can't handle relative URLs.

To reproduce:
- try to import the recipe at <https://cook.chatoyer.de/recipes/2634101413791153>
- notice that it doesn't get imported after pressing "Save"

I additionally wrapped the image loading call into a `try except` because I think that the recipe should still import fine even if the image can't be loaded (i.e. the image URL doesn't resolve). Might be good to show a warning to the user that the app failed to load the image, but I think that'd be too complex to implement.

Cheers